### PR TITLE
Refactor glitchlings into dedicated subclasses

### DIFF
--- a/src/glitchlings/main.py
+++ b/src/glitchlings/main.py
@@ -1,3 +1,5 @@
+"""Command line interface for summoning and running glitchlings."""
+
 from __future__ import annotations
 
 import argparse
@@ -38,6 +40,12 @@ MAX_NAME_WIDTH = max(len(glitchling.name) for glitchling in BUILTIN_GLITCHLINGS.
 
 
 def build_parser() -> argparse.ArgumentParser:
+    """Create and configure the CLI argument parser.
+
+    Returns:
+        argparse.ArgumentParser: The configured argument parser instance.
+    """
+
     parser = argparse.ArgumentParser(
         description=(
             "Summon glitchlings to corrupt text. Provide input text as an argument, "
@@ -89,6 +97,8 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def list_glitchlings() -> None:
+    """Print information about the available built-in glitchlings."""
+
     for key in DEFAULT_GLITCHLING_NAMES:
         glitchling = BUILTIN_GLITCHLINGS[key]
         display_name = glitchling.name
@@ -98,6 +108,19 @@ def list_glitchlings() -> None:
 
 
 def read_text(args: argparse.Namespace, parser: argparse.ArgumentParser) -> str:
+    """Resolve the input text based on CLI arguments.
+
+    Args:
+        args: Parsed arguments from the CLI.
+        parser: The argument parser used for emitting user-facing errors.
+
+    Returns:
+        str: The text to corrupt.
+
+    Raises:
+        SystemExit: Raised indirectly via ``parser.error`` on failure.
+    """
+
     if args.file is not None:
         try:
             return args.file.read_text(encoding="utf-8")
@@ -122,6 +145,21 @@ def read_text(args: argparse.Namespace, parser: argparse.ArgumentParser) -> str:
 def summon_glitchlings(
     names: list[str] | None, parser: argparse.ArgumentParser, seed: int
 ) -> Gaggle:
+    """Instantiate the requested glitchlings and bundle them in a ``Gaggle``.
+
+    Args:
+        names: Optional list of glitchling names provided by the user.
+        parser: The argument parser used for emitting user-facing errors.
+        seed: Master seed controlling deterministic corruption order.
+
+    Returns:
+        Gaggle: A ready-to-use collection of glitchlings.
+
+    Raises:
+        SystemExit: Raised indirectly via ``parser.error`` when a provided glitchling
+        name is invalid.
+    """
+
     if names:
         normalized = [name.lower() for name in names]
     else:
@@ -135,6 +173,8 @@ def summon_glitchlings(
 
 
 def show_diff(original: str, corrupted: str) -> None:
+    """Display a unified diff between the original and corrupted text."""
+
     diff_lines = list(
         difflib.unified_diff(
             original.splitlines(keepends=True),
@@ -152,6 +192,16 @@ def show_diff(original: str, corrupted: str) -> None:
 
 
 def run_cli(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
+    """Execute the CLI workflow using the provided arguments.
+
+    Args:
+        args: Parsed CLI arguments.
+        parser: Argument parser used for error reporting.
+
+    Returns:
+        int: Exit code for the process (``0`` on success).
+    """
+
     if args.list:
         list_glitchlings()
         return 0
@@ -170,6 +220,15 @@ def run_cli(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Entry point for the ``glitchlings`` command line interface.
+
+    Args:
+        argv: Optional list of command line arguments. Defaults to ``sys.argv``.
+
+    Returns:
+        int: Exit code suitable for use with ``sys.exit``.
+    """
+
     parser = build_parser()
     args = parser.parse_args(argv)
     return run_cli(args, parser)

--- a/src/glitchlings/zoo/__init__.py
+++ b/src/glitchlings/zoo/__init__.py
@@ -1,19 +1,26 @@
-from .typogre import typogre
-from .mim1c import mim1c
-from .jargoyle import jargoyle
-from .reduple import reduple
-from .rushmore import rushmore
-from .redactyl import redactyl
-from .scannequin import scannequin
+from .typogre import Typogre, typogre
+from .mim1c import Mim1c, mim1c
+from .jargoyle import Jargoyle, jargoyle
+from .reduple import Reduple, reduple
+from .rushmore import Rushmore, rushmore
+from .redactyl import Redactyl, redactyl
+from .scannequin import Scannequin, scannequin
 from .core import Glitchling, Gaggle
 
 __all__ = [
+    "Typogre",
     "typogre",
+    "Mim1c",
     "mim1c",
+    "Jargoyle",
     "jargoyle",
+    "Reduple",
     "reduple",
+    "Rushmore",
     "rushmore",
+    "Redactyl",
     "redactyl",
+    "Scannequin",
     "scannequin",
     "Glitchling",
     "Gaggle",

--- a/src/glitchlings/zoo/core.py
+++ b/src/glitchlings/zoo/core.py
@@ -1,9 +1,15 @@
+"""Core data structures used to model glitchlings and their interactions."""
+
 from enum import IntEnum, auto
 from datasets import Dataset
 import random
-from typing import Any, Callable
+from typing import Any, Protocol
 
-import functools as ft
+
+class CorruptionCallable(Protocol):
+    """Protocol describing a callable capable of corrupting text."""
+
+    def __call__(self, text: str, *args: Any, **kwargs: Any) -> str: ...
 
 
 # Text levels for glitchlings, to enforce a sort order
@@ -11,6 +17,8 @@ import functools as ft
 # duplicating a word then adding a typo is potentially different than
 # adding a typo then duplicating a word
 class AttackWave(IntEnum):
+    """Granularity of text that a glitchling corrupts."""
+
     DOCUMENT = auto()
     PARAGRAPH = auto()
     SENTENCE = auto()
@@ -20,6 +28,8 @@ class AttackWave(IntEnum):
 
 # Modifier for within the same attack wave
 class AttackOrder(IntEnum):
+    """Relative execution order for glitchlings within the same wave."""
+
     FIRST = auto()
     EARLY = auto()
     NORMAL = auto()
@@ -28,32 +38,49 @@ class AttackOrder(IntEnum):
 
 
 class Glitchling:
+    """A single text corruption agent with deterministic behaviour."""
+
     def __init__(
         self,
         name: str,
-        corruption_function: Callable,
+        corruption_function: CorruptionCallable,
         scope: AttackWave,
         order: AttackOrder = AttackOrder.NORMAL,
         seed: int | None = None,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
+        """Initialize a glitchling.
+
+        Args:
+            name: Human readable glitchling name.
+            corruption_function: Callable used to transform text.
+            scope: Text granularity on which the glitchling operates.
+            order: Relative ordering within the same scope.
+            seed: Optional seed for deterministic random behaviour.
+            **kwargs: Additional parameters forwarded to the corruption callable.
+        """
+
         # Each Glitchling maintains its own RNG for deterministic yet isolated behavior.
         # If no seed is supplied, we fall back to Python's default entropy.
         self.seed = seed
         self.rng: random.Random = random.Random(seed)
         self.name: str = name
-        self.corruption_function: Callable[..., str] = corruption_function
+        self.corruption_function: CorruptionCallable = corruption_function
         self.level: AttackWave = scope
         self.order: AttackOrder = order
         self.kwargs: dict[str, Any] = {}
         for kw, val in kwargs.items():
             self.set_param(kw, val)
 
-    def set_param(self, key: str, value: Any):
+    def set_param(self, key: str, value: Any) -> None:
+        """Persist a parameter for use by the corruption callable."""
+
         setattr(self, key, value)
         self.kwargs[key] = value
 
-    def __corrupt(self, text, *args, **kwargs):
+    def __corrupt(self, text: str, *args: Any, **kwargs: Any) -> str:
+        """Execute the corruption callable, injecting the RNG when required."""
+
         # Pass rng to underlying corruption function if it expects it.
         if "rng" in self.corruption_function.__code__.co_varnames:
             corrupted = self.corruption_function(text, *args, rng=self.rng, **kwargs)
@@ -61,7 +88,9 @@ class Glitchling:
             corrupted = self.corruption_function(text, *args, **kwargs)
         return corrupted
 
-    def corrupt(self, text: str | list[dict]) -> str | list[dict]:
+    def corrupt(self, text: str | list[dict[str, Any]]) -> str | list[dict[str, Any]]:
+        """Apply the corruption function to text or conversational transcripts."""
+
         if isinstance(text, list):
             text[-1]["content"] = self.__corrupt(text[-1]["content"], **self.kwargs)
         else:
@@ -70,7 +99,9 @@ class Glitchling:
         return text
 
     def corrupt_dataset(self, dataset: Dataset, columns: list[str]) -> Dataset:
-        def __corrupt_row(row):
+        """Apply corruption across multiple dataset columns."""
+
+        def __corrupt_row(row: dict[str, Any]) -> dict[str, Any]:
             for column in columns:
                 row[column] = self.corrupt(row[column])
             return row
@@ -79,33 +110,51 @@ class Glitchling:
 
         return dataset
 
-    def __call__(self, text: str, *args, **kwds) -> str | list[dict]:
+    def __call__(self, text: str, *args: Any, **kwds: Any) -> str | list[dict[str, Any]]:
+        """Allow a glitchling to be invoked directly like a callable."""
+
         return self.corrupt(text, *args, **kwds)
 
-    def reset_rng(self, seed=None):
-        """Reset this glitchling's RNG to its initial seed (if one was provided)."""
+    def reset_rng(self, seed: int | None = None) -> None:
+        """Reset the glitchling's RNG to its initial seed."""
+
         if seed is not None:
             self.seed = seed
         if self.seed is not None:
             self.rng = random.Random(self.seed)
 
-    def clone(self, seed=None) -> "Glitchling":
+    def clone(self, seed: int | None = None) -> "Glitchling":
         """Create a copy of this glitchling, optionally with a new seed."""
-        # Avoid passing duplicate 'seed' through kwargs if it was set via set_param
+
+        cls = self.__class__
         filtered_kwargs = {k: v for k, v in self.kwargs.items() if k != "seed"}
-        new_glitchling = Glitchling(
-            self.name,
-            self.corruption_function,
-            self.level,
-            self.order,
-            seed=seed if seed is not None else self.seed,
-            **filtered_kwargs,
-        )
-        return new_glitchling
+        clone_seed = seed if seed is not None else self.seed
+        if clone_seed is not None:
+            filtered_kwargs["seed"] = clone_seed
+
+        if cls is Glitchling:
+            return Glitchling(
+                self.name,
+                self.corruption_function,
+                self.level,
+                self.order,
+                **filtered_kwargs,
+            )
+
+        return cls(**filtered_kwargs)
 
 
 class Gaggle(Glitchling):
+    """A collection of glitchlings executed in a deterministic order."""
+
     def __init__(self, glitchlings: list[Glitchling], seed: int = 151):
+        """Initialize the gaggle and derive per-glitchling RNG seeds.
+
+        Args:
+            glitchlings: Glitchlings to orchestrate.
+            seed: Master seed used to derive per-glitchling seeds.
+        """
+
         super().__init__("Gaggle", self.corrupt, AttackWave.DOCUMENT, seed=seed)
         self.glitchlings: dict[AttackWave, list[Glitchling]] = {
             level: [] for level in AttackWave
@@ -124,7 +173,9 @@ class Gaggle(Glitchling):
         """Derive a deterministic seed for a glitchling based on the master seed."""
         return hash((master_seed, glitchling_name, index)) & 0xFFFFFFFF
 
-    def sort_glitchlings(self):
+    def sort_glitchlings(self) -> None:
+        """Sort glitchlings by wave then order to produce application order."""
+
         self.apply_order = [
             g
             for _, glitchlings in sorted(self.glitchlings.items())
@@ -132,6 +183,8 @@ class Gaggle(Glitchling):
         ]
 
     def corrupt(self, text: str) -> str:
+        """Apply each glitchling to the provided text sequentially."""
+
         corrupted = text
         for glitchling in self.apply_order:
             corrupted = glitchling(corrupted)

--- a/src/glitchlings/zoo/jargoyle.py
+++ b/src/glitchlings/zoo/jargoyle.py
@@ -105,8 +105,27 @@ def substitute_random_synonyms(
     return "".join(tokens)
 
 
-jargoyle = Glitchling(
-    name="Jargoyle",
-    corruption_function=substitute_random_synonyms,
-    scope=AttackWave.WORD,
-)
+class Jargoyle(Glitchling):
+    """Glitchling that swaps words with random WordNet synonyms."""
+
+    def __init__(
+        self,
+        *,
+        replacement_rate: float = 0.1,
+        part_of_speech: Literal["n", "v", "a", "r"] = "n",
+        seed: int | None = None,
+    ) -> None:
+        super().__init__(
+            name="Jargoyle",
+            corruption_function=substitute_random_synonyms,
+            scope=AttackWave.WORD,
+            seed=seed,
+            replacement_rate=replacement_rate,
+            part_of_speech=part_of_speech,
+        )
+
+
+jargoyle = Jargoyle()
+
+
+__all__ = ["Jargoyle", "jargoyle"]

--- a/src/glitchlings/zoo/mim1c.py
+++ b/src/glitchlings/zoo/mim1c.py
@@ -52,11 +52,28 @@ def swap_homoglyphs(
     return text
 
 
-mim1c = Glitchling(
-    name="Mim1c",
-    corruption_function=swap_homoglyphs,
-    scope=AttackWave.CHARACTER,
-    order=AttackOrder.LAST,
-    replacement_rate=0.02,
-    classes=["LATIN", "GREEK", "CYRILLIC"],
-)
+class Mim1c(Glitchling):
+    """Glitchling that swaps characters for visually similar homoglyphs."""
+
+    def __init__(
+        self,
+        *,
+        replacement_rate: float = 0.02,
+        classes: list[str] | Literal["all"] | None = None,
+        seed: int | None = None,
+    ) -> None:
+        super().__init__(
+            name="Mim1c",
+            corruption_function=swap_homoglyphs,
+            scope=AttackWave.CHARACTER,
+            order=AttackOrder.LAST,
+            seed=seed,
+            replacement_rate=replacement_rate,
+            classes=classes,
+        )
+
+
+mim1c = Mim1c()
+
+
+__all__ = ["Mim1c", "mim1c"]

--- a/src/glitchlings/zoo/redactyl.py
+++ b/src/glitchlings/zoo/redactyl.py
@@ -63,11 +63,29 @@ def redact_words(
     return text
 
 
-redactyl = Glitchling(
-    name="Redactyl",
-    corruption_function=redact_words,
-    replacement_char=FULL_BLOCK,
-    redaction_rate=0.05,
-    scope=AttackWave.WORD,
-    seed=151,
-)
+class Redactyl(Glitchling):
+    """Glitchling that redacts words with block characters."""
+
+    def __init__(
+        self,
+        *,
+        replacement_char: str = FULL_BLOCK,
+        redaction_rate: float = 0.05,
+        merge_adjacent: bool = False,
+        seed: int = 151,
+    ) -> None:
+        super().__init__(
+            name="Redactyl",
+            corruption_function=redact_words,
+            scope=AttackWave.WORD,
+            seed=seed,
+            replacement_char=replacement_char,
+            redaction_rate=redaction_rate,
+            merge_adjacent=merge_adjacent,
+        )
+
+
+redactyl = Redactyl()
+
+
+__all__ = ["Redactyl", "redactyl"]

--- a/src/glitchlings/zoo/reduple.py
+++ b/src/glitchlings/zoo/reduple.py
@@ -49,6 +49,25 @@ def reduplicate_words(
     return "".join(tokens)
 
 
-reduple = Glitchling(
-    name="Reduple", corruption_function=reduplicate_words, scope=AttackWave.WORD
-)
+class Reduple(Glitchling):
+    """Glitchling that repeats words to simulate stuttering speech."""
+
+    def __init__(
+        self,
+        *,
+        reduplication_rate: float = 0.05,
+        seed: int | None = None,
+    ) -> None:
+        super().__init__(
+            name="Reduple",
+            corruption_function=reduplicate_words,
+            scope=AttackWave.WORD,
+            seed=seed,
+            reduplication_rate=reduplication_rate,
+        )
+
+
+reduple = Reduple()
+
+
+__all__ = ["Reduple", "reduple"]

--- a/src/glitchlings/zoo/rushmore.py
+++ b/src/glitchlings/zoo/rushmore.py
@@ -50,4 +50,25 @@ def delete_random_words(
     return text
 
 
-rushmore = Glitchling("rushmore", delete_random_words, scope=AttackWave.WORD)
+class Rushmore(Glitchling):
+    """Glitchling that deletes words to simulate missing information."""
+
+    def __init__(
+        self,
+        *,
+        max_deletion_rate: float = 0.01,
+        seed: int | None = None,
+    ) -> None:
+        super().__init__(
+            name="Rushmore",
+            corruption_function=delete_random_words,
+            scope=AttackWave.WORD,
+            seed=seed,
+            max_deletion_rate=max_deletion_rate,
+        )
+
+
+rushmore = Rushmore()
+
+
+__all__ = ["Rushmore", "rushmore"]

--- a/src/glitchlings/zoo/scannequin.py
+++ b/src/glitchlings/zoo/scannequin.py
@@ -115,10 +115,26 @@ def ocr_artifacts(
     return "".join(out_parts)
 
 
-scannequin = Glitchling(
-    name="Scannequin",
-    corruption_function=ocr_artifacts,
-    scope=AttackWave.CHARACTER,
-    order=AttackOrder.LATE,
-    error_rate=0.02,
-)
+class Scannequin(Glitchling):
+    """Glitchling that simulates OCR artifacts using common confusions."""
+
+    def __init__(
+        self,
+        *,
+        error_rate: float = 0.02,
+        seed: int | None = None,
+    ) -> None:
+        super().__init__(
+            name="Scannequin",
+            corruption_function=ocr_artifacts,
+            scope=AttackWave.CHARACTER,
+            order=AttackOrder.LATE,
+            seed=seed,
+            error_rate=error_rate,
+        )
+
+
+scannequin = Scannequin()
+
+
+__all__ = ["Scannequin", "scannequin"]

--- a/src/glitchlings/zoo/typogre.py
+++ b/src/glitchlings/zoo/typogre.py
@@ -204,9 +204,28 @@ def fatfinger(
     return s
 
 
-typogre = Glitchling(
-    name="Typogre",
-    corruption_function=fatfinger,
-    scope=AttackWave.CHARACTER,
-    order=AttackOrder.EARLY,
-)
+class Typogre(Glitchling):
+    """Glitchling that introduces deterministic keyboard-typing errors."""
+
+    def __init__(
+        self,
+        *,
+        max_change_rate: float = 0.02,
+        keyboard: str = "CURATOR_QWERTY",
+        seed: int | None = None,
+    ) -> None:
+        super().__init__(
+            name="Typogre",
+            corruption_function=fatfinger,
+            scope=AttackWave.CHARACTER,
+            order=AttackOrder.EARLY,
+            seed=seed,
+            max_change_rate=max_change_rate,
+            keyboard=keyboard,
+        )
+
+
+typogre = Typogre()
+
+
+__all__ = ["Typogre", "typogre"]


### PR DESCRIPTION
## Summary
- refactor each named glitchling into its own subclass with configurable parameters while keeping default instances available
- teach `Glitchling.clone` to preserve subclass types and expose the new classes through the zoo package exports

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db0a472c108332b565f22845e8a327