### PR TITLE
Expand jargoyle POS support and keyboard layouts

### DIFF
--- a/MONSTER_MANUAL.md
+++ b/MONSTER_MANUAL.md
@@ -56,12 +56,12 @@ _What a nice word, would be a shame if something happened to it._
 > ---
 >
 > _**Fatfinger.**_ Typogre introduces character-level errors (duplicating, dropping, adding, or swapping)
-> based on the layout of a (currently QWERTY) keyboard.
+> based on the layout of a keyboard (QWERTY by default, with Dvorak and Colemak variants built-in).
 >
 > ### Typogre Args
 >
 > - `max_change_rate (float)`: The maximum number of edits to make as a percentage of the length (default: 0.02, 2%).
-> - `keyboard (str)`: Keyboard layout key-neighbor map to use (default: "CURATOR_QWERTY").
+> - `keyboard (str)`: Keyboard layout key-neighbor map to use (default: "CURATOR_QWERTY"; also accepts "CURATOR_DVORAK" and "CURATOR_COLEMAK").
 > - `seed (int)`: The random seed for reproducibility (default: 151).
 >
 > ```python
@@ -145,12 +145,12 @@ _Uh oh. The worst person you know just bought a thesaurus._
 >
 > ---
 >
-> _**Sesquipedalianism.**_ Jargoyle, the insufferable `Glitchling`, replaces nouns with synonyms at random, without regard for connotational or denotational differences.
+> _**Sesquipedalianism.**_ Jargoyle, the insufferable `Glitchling`, replaces words from selected parts of speech with synonyms at random, without regard for connotational or denotational differences.
 >
 > ### Jargoyle Args
 >
 > - `replacement_rate (float)`: The maximum proportion of words to replace (default: 0.1, 10%).
-> - `part_of_speech`: The WordNet part of speech to target (default: nouns). Accepts `wn.NOUN`, `wn.VERB`, `wn.ADJ`, or `wn.ADV`.
+> - `part_of_speech`: The WordNet part(s) of speech to target (default: nouns). Accepts `wn.NOUN`, `wn.VERB`, `wn.ADJ`, `wn.ADV`, any iterable of those tags, or the string `"any"` to include them all.
 > - `seed (int)`: The random seed for reproducibility (default: 151).
 >
 > ```python

--- a/README.md
+++ b/README.md
@@ -110,12 +110,12 @@ For maintainability reasons, all `Glitchling` have consented to be given nicknam
 
 _What a nice word, would be a shame if something happened to it._
 
-> _**Fatfinger.**_ Typogre introduces character-level errors (duplicating, dropping, adding, or swapping) based on the layout of a (currently QWERTY) keyboard.
+> _**Fatfinger.**_ Typogre introduces character-level errors (duplicating, dropping, adding, or swapping) based on the layout of a keyboard (QWERTY by default, with Dvorak and Colemak variants built-in).
 >
 > Args
 >
 > - `max_change_rate (float)`: The maximum number of edits to make as a percentage of the length (default: 0.02, 2%).
-> - `keyboard (str)`: Keyboard layout key-neighbor map to use (default: "CURATOR_QWERTY").
+> - `keyboard (str)`: Keyboard layout key-neighbor map to use (default: "CURATOR_QWERTY"; also accepts "CURATOR_DVORAK" and "CURATOR_COLEMAK").
 > - `seed (int)`: The random seed for reproducibility (default: 151).
 
 ### Mim1c
@@ -145,12 +145,12 @@ _How can a computer need reading glasses?_
 
 _Uh oh. The worst person you know just bought a thesaurus._
 
-> _**Sesquipedalianism.**_ Jargoyle, the insufferable `Glitchling`, replaces nouns with synonyms at random, without regard for connotational or denotational differences.
+> _**Sesquipedalianism.**_ Jargoyle, the insufferable `Glitchling`, replaces words from selected parts of speech with synonyms at random, without regard for connotational or denotational differences.
 >
 > Args
 >
 > - `replacement_rate (float)`: The maximum proportion of words to replace (default: 0.1, 10%).
-> - `part_of_speech`: The WordNet part of speech to target (default: nouns). Accepts `wn.NOUN`, `wn.VERB`, `wn.ADJ`, or `wn.ADV`.
+> - `part_of_speech`: The WordNet part(s) of speech to target (default: nouns). Accepts `wn.NOUN`, `wn.VERB`, `wn.ADJ`, `wn.ADV`, any iterable of those tags, or the string `"any"` to include them all.
 > - `seed (int)`: The random seed for reproducibility (default: 151).
 
 ### Reduple

--- a/tests/test_jargoyle.py
+++ b/tests/test_jargoyle.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import pytest
+
+from glitchlings.zoo.jargoyle import substitute_random_synonyms
+from nltk.corpus import wordnet as wn
+
+
+try:  # pragma: no cover - this only guards against missing corpora
+    wn.ensure_loaded()
+except LookupError:  # pragma: no cover - skip marker handles the branch
+    WORDNET_AVAILABLE = False
+else:
+    WORDNET_AVAILABLE = True
+
+
+pytestmark = pytest.mark.skipif(
+    not WORDNET_AVAILABLE,
+    reason="NLTK WordNet corpus unavailable; skipping jargoyle POS tests.",
+)
+
+
+def _clean_tokens(text: str) -> list[str]:
+    return [token.strip(".,") for token in text.split()]
+
+
+def test_jargoyle_multiple_pos_targets_change_words():
+    text = "They sing happy songs."
+    result = substitute_random_synonyms(
+        text,
+        replacement_rate=1.0,
+        part_of_speech=("v", "a"),
+        seed=123,
+    )
+
+    original_tokens = _clean_tokens(text)
+    result_tokens = _clean_tokens(result)
+
+    # Expect both verb and adjective replacements to differ from input
+    changed = {
+        orig for orig, new in zip(original_tokens, result_tokens) if orig != new
+    }
+    assert {"sing", "happy"} <= changed
+
+
+def test_jargoyle_any_includes_all_supported_pos():
+    text = "They sing happy songs quickly."
+    result = substitute_random_synonyms(
+        text,
+        replacement_rate=1.0,
+        part_of_speech="any",
+        seed=99,
+    )
+
+    original_tokens = _clean_tokens(text)
+    result_tokens = _clean_tokens(result)
+
+    changed = {
+        orig for orig, new in zip(original_tokens, result_tokens) if orig != new
+    }
+    assert {"sing", "happy", "songs", "quickly"} <= changed


### PR DESCRIPTION
## Summary
- extend the jargoyle glitchling to accept multiple WordNet parts of speech, including an "any" shortcut
- document the broader jargoyle coverage and add tests that exercise adjective, verb, adverb, and noun replacements
- add CURATOR_DVORAK and CURATOR_COLEMAK keyboard neighbor maps with documentation for Typogre

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbe91c0c4c8332a6eb861f39b1dc1f