### PR TITLE
Handle empty inputs in Redactyl Python fallback

### DIFF
--- a/src/glitchlings/zoo/redactyl.py
+++ b/src/glitchlings/zoo/redactyl.py
@@ -33,6 +33,8 @@ def _python_redact_words(
     # Preserve exact spacing and punctuation by using regex
     tokens = re.split(r"(\s+)", text)
     word_indices = [i for i, token in enumerate(tokens) if i % 2 == 0 and token.strip()]
+    if not word_indices:
+        raise ValueError("Cannot redact words because the input text contains no redactable words.")
     num_to_redact = max(1, int(len(word_indices) * redaction_rate))
 
     # Sample from the indices of actual words

--- a/tests/test_rust_backed_glitchlings.py
+++ b/tests/test_rust_backed_glitchlings.py
@@ -99,5 +99,12 @@ def test_redactyl_merge_adjacent_blocks():
 
 
 def test_redactyl_empty_text_raises_value_error():
-    with pytest.raises(ValueError):
+    message = "contains no redactable words"
+    with pytest.raises(ValueError, match=message):
         redactyl_module.redact_words("", seed=1)
+
+
+def test_redactyl_whitespace_only_text_raises_value_error():
+    message = "contains no redactable words"
+    with pytest.raises(ValueError, match=message):
+        redactyl_module.redact_words("   \t\n  ", seed=2)


### PR DESCRIPTION
## Summary
- raise a descriptive ValueError from the Python Redactyl implementation when no words are found
- adjust Redactyl empty input test expectations and add whitespace-only coverage

## Testing
- pytest tests/test_rust_backed_glitchlings.py::test_redactyl_empty_text_raises_value_error tests/test_rust_backed_glitchlings.py::test_redactyl_whitespace_only_text_raises_value_error

------
https://chatgpt.com/codex/tasks/task_e_68ddb73b7d5c83329a515dac25a2ffed