### PR TITLE
Replace gaggle seed hashing with deterministic digest

### DIFF
--- a/src/glitchlings/zoo/core.py
+++ b/src/glitchlings/zoo/core.py
@@ -1,6 +1,7 @@
 """Core data structures used to model glitchlings and their interactions."""
 
 from enum import IntEnum, auto
+from hashlib import blake2s
 from datasets import Dataset
 import random
 from typing import Any, Protocol
@@ -170,7 +171,29 @@ class Gaggle(Glitchling):
     @staticmethod
     def derive_seed(master_seed: int, glitchling_name: str, index: int) -> int:
         """Derive a deterministic seed for a glitchling based on the master seed."""
-        return hash((master_seed, glitchling_name, index)) & 0xFFFFFFFF
+        def _int_to_bytes(value: int) -> bytes:
+            if value == 0:
+                return b"\x00"
+
+            abs_value = abs(value)
+            length = max(1, (abs_value.bit_length() + 7) // 8)
+
+            if value < 0:
+                while True:
+                    try:
+                        return value.to_bytes(length, "big", signed=True)
+                    except OverflowError:
+                        length += 1
+
+            return abs_value.to_bytes(length, "big", signed=False)
+
+        hasher = blake2s(digest_size=8)
+        hasher.update(_int_to_bytes(master_seed))
+        hasher.update(b"\x00")
+        hasher.update(glitchling_name.encode("utf-8"))
+        hasher.update(b"\x00")
+        hasher.update(_int_to_bytes(index))
+        return int.from_bytes(hasher.digest(), "big")
 
     def sort_glitchlings(self) -> None:
         """Sort glitchlings by wave then order to produce application order."""

--- a/tests/test_gaggle.py
+++ b/tests/test_gaggle.py
@@ -1,4 +1,5 @@
 from glitchlings import summon
+from glitchlings.zoo.core import Gaggle
 
 
 def test_gaggle_determinism(sample_text):
@@ -24,3 +25,8 @@ def test_gaggle_ordering_stable(sample_text):
         "r",
         "r",
     ]
+
+
+def test_gaggle_seed_derivation_regression():
+    assert Gaggle.derive_seed(151, "Typogre", 0) == 13006513535068165406
+    assert Gaggle.derive_seed(151, "Redactyl", 3) == 12503957440331561761


### PR DESCRIPTION
## Summary
- derive gaggle seeds using a blake2s digest of the master seed, glitchling name, and index
- add regression coverage for the new deterministic seed values

## Testing
- pytest tests/test_gaggle.py

------
https://chatgpt.com/codex/tasks/task_e_68ddb725105c83328112febe950484c0