### PR TITLE
Limit Rushmore deletions to configured cap

### DIFF
--- a/tests/test_parameter_effects.py
+++ b/tests/test_parameter_effects.py
@@ -1,3 +1,4 @@
+import math
 from typing import cast
 from glitchlings import typogre, mim1c, reduple, rushmore, redactyl, scannequin
 
@@ -31,6 +32,21 @@ def test_rushmore_rate_decreases_tokens():
     rushmore.set_param("max_deletion_rate", 0.5)
     out = cast(str, rushmore(text))
     assert len(out.split()) <= len(text.split())
+
+
+def test_rushmore_max_deletion_cap():
+    text = "alpha beta gamma delta epsilon zeta eta theta"
+    words = text.split()
+    candidate_count = max(len(words) - 1, 0)
+
+    for rate, seed in [(0.1, 3), (0.5, 11), (1.0, 17)]:
+        rushmore.set_param("seed", seed)
+        rushmore.set_param("max_deletion_rate", rate)
+        out = cast(str, rushmore(text))
+
+        removed = len(words) - len(out.split())
+        allowed = min(candidate_count, math.floor(candidate_count * rate))
+        assert removed <= allowed
 
 
 def test_redactyl_replacement_char_and_merge():


### PR DESCRIPTION
## Summary
- refactor the Python Rushmore implementation to compute candidate indices and cap deletions based on the configured rate
- ensure the deletion routine removes no more than the allowed number of words while preserving punctuation handling
- add parameter effects coverage that checks Rushmore never removes more tokens than permitted for representative inputs

## Testing
- pytest tests/test_parameter_effects.py

------
https://chatgpt.com/codex/tasks/task_e_68ddb7357ecc83328d3161c762f30ebd