### PR TITLE
Fix RNG injection and Rushmore sampling

### DIFF
--- a/src/glitchlings/zoo/core.py
+++ b/src/glitchlings/zoo/core.py
@@ -1,10 +1,9 @@
 """Core data structures used to model glitchlings and their interactions."""
 
-from enum import IntEnum, auto
-from hashlib import blake2s
-from datasets import Dataset
+import inspect
 import random
 from enum import IntEnum, auto
+from hashlib import blake2s
 from typing import Any, Protocol
 
 from datasets import Dataset
@@ -81,6 +80,8 @@ class Glitchling:
 
         setattr(self, key, value)
         self.kwargs[key] = value
+        if key == "seed":
+            self.reset_rng(value)
 
     def __corrupt(self, text: str, *args: Any, **kwargs: Any) -> str:
         """Execute the corruption callable, injecting the RNG when required."""


### PR DESCRIPTION
## Summary
- reset each glitchling's RNG whenever its seed parameter changes so seed updates take effect immediately
- update Rushmore's Python fallback to match the CLI corruption behaviour while still respecting whitespace handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddca50ead083328192c512cbe717d3