### PR TITLE
Add stdin fallback test for read_text

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -130,3 +130,21 @@ def test_read_text_requires_input(monkeypatch, capsys):
         read_text(args, parser)
     captured = capsys.readouterr()
     assert "No input text provided" in captured.err
+
+
+def test_read_text_consumes_stdin(monkeypatch):
+    parser = build_parser()
+    args = parser.parse_args([])
+
+    sentinel = "stdin payload"
+
+    class DummyStdin:
+        def isatty(self):
+            return False
+
+        def read(self):
+            return sentinel
+
+    monkeypatch.setattr("sys.stdin", DummyStdin())
+
+    assert read_text(args, parser) == sentinel


### PR DESCRIPTION
## Summary
- add a test ensuring `read_text` consumes non-tty stdin input

## Testing
- pytest tests/test_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68def5f2e5b88332a92755367025b7ca