### PR TITLE
Add tests for string_diffs grouping behavior

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,35 @@
+import pytest
+
+from glitchlings.util import string_diffs
+
+
+def test_string_diffs_groups_consecutive_edits_and_skips_equals():
+    result = string_diffs("kitten", "sitting")
+
+    assert result == [
+        [("replace", "k", "s")],
+        [("replace", "e", "i")],
+        [("insert", "", "g")],
+    ]
+
+    for group in result:
+        assert group
+        assert all(tag != "equal" for tag, *_ in group)
+
+
+@pytest.mark.parametrize(
+    "a,b,expected",
+    [
+        ("flaw", "lawn", [[("delete", "f", "")], [("insert", "", "n")]]),
+        (
+            "distance",
+            "instance",
+            [
+                [("delete", "d", "")],
+                [("insert", "", "n")],
+            ],
+        ),
+    ],
+)
+def test_string_diffs_handles_multiple_edit_groups(a: str, b: str, expected: list[list[tuple[str, str, str]]]):
+    assert string_diffs(a, b) == expected


### PR DESCRIPTION
## Summary
- add regression tests for string_diffs covering replacement/insertion grouping
- exercise multiple disjoint edit groups to confirm buffer flushing

## Testing
- PYTHONPATH=src pytest tests/test_util.py

------
https://chatgpt.com/codex/tasks/task_e_68def5da94288332a39820e7e549b92a