### PR TITLE
Improve CLI error message for missing input files

### DIFF
--- a/src/glitchlings/main.py
+++ b/src/glitchlings/main.py
@@ -124,8 +124,10 @@ def read_text(args: argparse.Namespace, parser: argparse.ArgumentParser) -> str:
     if args.file is not None:
         try:
             return args.file.read_text(encoding="utf-8")
-        except OSError as exc:  # pragma: no cover - exercised via CLI
-            parser.error(str(exc))
+        except OSError as exc:
+            filename = getattr(exc, "filename", None) or args.file
+            reason = exc.strerror or str(exc)
+            parser.error(f"Failed to read file {filename}: {reason}")
 
     if args.text:
         return args.text


### PR DESCRIPTION
## Summary
- surface a clearer error when the CLI cannot read an input file by including the path and OS reason

## Testing
- pytest tests/test_cli.py::test_read_text_reports_missing_file -q

------
https://chatgpt.com/codex/tasks/task_e_68e02f6dce288332a91829d75db18c3e