### PR TITLE
Prevent transcript dataset corruption from compounding

### DIFF
--- a/src/glitchlings/zoo/core.py
+++ b/src/glitchlings/zoo/core.py
@@ -9,6 +9,21 @@ from typing import Any, Protocol
 from datasets import Dataset
 
 
+def _is_transcript(value: Any) -> bool:
+    """Return True when the value resembles a chat transcript."""
+
+    if not isinstance(value, list):
+        return False
+
+    if not value:
+        return True
+
+    if not all(isinstance(turn, dict) for turn in value):
+        return False
+
+    return "content" in value[-1]
+
+
 class CorruptionCallable(Protocol):
     """Protocol describing a callable capable of corrupting text."""
 
@@ -105,12 +120,15 @@ class Glitchling:
     def corrupt(self, text: str | list[dict[str, Any]]) -> str | list[dict[str, Any]]:
         """Apply the corruption function to text or conversational transcripts."""
 
-        if isinstance(text, list):
-            text[-1]["content"] = self.__corrupt(text[-1]["content"], **self.kwargs)
-        else:
-            text = self.__corrupt(text, **self.kwargs)
+        if _is_transcript(text):
+            transcript = [dict(turn) for turn in text]
+            if transcript:
+                transcript[-1]["content"] = self.__corrupt(
+                    transcript[-1]["content"], **self.kwargs
+                )
+            return transcript
 
-        return text
+        return self.__corrupt(text, **self.kwargs)
 
     def corrupt_dataset(self, dataset: Dataset, columns: list[str]) -> Dataset:
         """Apply corruption lazily across dataset columns."""
@@ -119,7 +137,9 @@ class Glitchling:
             row = dict(row)
             for column in columns:
                 value = row[column]
-                if isinstance(value, list):
+                if _is_transcript(value):
+                    row[column] = self.corrupt(value)
+                elif isinstance(value, list):
                     row[column] = [self.corrupt(item) for item in value]
                 else:
                     row[column] = self.corrupt(value)

--- a/tests/test_prime_echo_chamber.py
+++ b/tests/test_prime_echo_chamber.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from datasets import Dataset
+
+from glitchlings.zoo.core import AttackWave, Gaggle, Glitchling
+
+
+def append_marker(text: str) -> str:
+    """Deterministically mark the supplied text."""
+
+    return f"{text} :: corrupted"
+
+
+def test_prime_echo_chamber_prompt_corruption_is_stable() -> None:
+    """Repeated dataset corruption should not compound transcript changes."""
+
+    base_transcript = [
+        {"role": "system", "content": "System prompt"},
+        {"role": "user", "content": "Compute 2+2."},
+    ]
+
+    dataset = Dataset.from_dict({"prompt": [base_transcript], "id": [0]})
+
+    glitchling = Glitchling("marker", append_marker, AttackWave.SENTENCE)
+    gaggle = Gaggle([glitchling], seed=7)
+
+    first_pass = list(gaggle.corrupt_dataset(dataset, ["prompt"]))
+    second_pass = list(gaggle.corrupt_dataset(dataset, ["prompt"]))
+
+    assert first_pass == second_pass
+    assert first_pass[0]["prompt"][-1]["content"] == "Compute 2+2. :: corrupted"
+    assert base_transcript[-1]["content"] == "Compute 2+2."


### PR DESCRIPTION
## Summary
- clone chat transcripts before updating the final message content so mutations don't leak back to callers
- update dataset corruption to recognise transcript columns and return the cloned transcripts each time
- add a regression test covering repeated prime echo prompt corruption to ensure it stays stable

## Testing
- pytest tests/test_prime_echo_chamber.py

------
https://chatgpt.com/codex/tasks/task_e_68e057020d508332a38b27735a5420b3