### PR TITLE
Set wheel platform tag to manylinux

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+plat_name = manylinux_2_17_x86_64.manylinux2014_x86_64


### PR DESCRIPTION
## Summary
- configure the wheel build to emit a manylinux-compatible platform tag so uploads succeed on PyPI

## Testing
- python -m build --wheel

------
https://chatgpt.com/codex/tasks/task_e_68e0760d5eb08332b3241732d0fad3dc