### PR TITLE
Add banned character filtering to Mim1c

### DIFF
--- a/MONSTER_MANUAL.md
+++ b/MONSTER_MANUAL.md
@@ -106,6 +106,7 @@ _Wait, was that...?_
 >
 > - `replacement_rate (float)`: The maximum proportion of characters to replace (default: 0.02, 2%).
 > - `classes (list[str] | "all")`: Restrict replacements to these Unicode script classes (default: ["LATIN", "GREEK", "CYRILLIC"]).
+> - `banned_characters (Collection[str])`: Characters that must never appear as replacements (default: none).
 > - `seed (int)`: The random seed for reproducibility (default: 151).
 >
 > ```python

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ _Wait, was that...?_
 >
 > - `replacement_rate (float)`: The maximum proportion of characters to replace (default: 0.02, 2%).
 > - `classes (list[str] | "all")`: Restrict replacements to these Unicode script classes (default: ["LATIN", "GREEK", "CYRILLIC"]).
+> - `banned_characters (Collection[str])`: Characters that must never appear as replacements (default: none).
 > - `seed (int)`: The random seed for reproducibility (default: 151).
 
 ### Scannequin

--- a/docs/index.md
+++ b/docs/index.md
@@ -112,10 +112,11 @@ Each glitchling subclasses the shared `Glitchling` base class and exposes the sa
 ### Mim1c
 
 - **Scope**: character level (late attack order so it acts after insertions/deletions).
-- **Signature**: `Mim1c(replacement_rate=0.02, classes=None, seed=None)`.
+- **Signature**: `Mim1c(replacement_rate=0.02, classes=None, banned_characters=None, seed=None)`.
 - **Behaviour**: replaces alphanumeric characters with visually confusable Unicode homoglyphs via `confusable_homoglyphs` (e.g., `A → Α`, `e → е`). When `classes` is omitted it targets Latin, Greek, and Cyrillic scripts; pass `classes="all"` to consider every alias.
 - **Usage tips**:
   - Restrict `classes` (e.g., `classes=["LATIN"]`) when evaluation pipelines reject non-Latin scripts.
+  - Use `banned_characters` to exclude confusables that would break downstream filters (e.g., ban full-width ASCII when testing strict lexers).
   - Keep `replacement_rate` below 0.03 for legible perturbations; higher values can break tokenisers that expect ASCII.
   - Pairs well with Typogre for keyboard + homoglyph chaos.
 

--- a/src/glitchlings/zoo/mim1c.py
+++ b/src/glitchlings/zoo/mim1c.py
@@ -1,13 +1,17 @@
-from typing import Literal
-from .core import Glitchling, AttackWave, AttackOrder
+from collections.abc import Collection
 import random
+from typing import Literal
+
 from confusable_homoglyphs import confusables
+
+from .core import AttackOrder, AttackWave, Glitchling
 
 
 def swap_homoglyphs(
     text: str,
     replacement_rate: float = 0.02,
     classes: list[str] | Literal["all"] | None = None,
+    banned_characters: Collection[str] | None = None,
     seed: int | None = None,
     rng: random.Random | None = None,
 ) -> str:
@@ -17,6 +21,7 @@ def swap_homoglyphs(
     - text: Input text.
     - replacement_rate: Max proportion of eligible characters to replace (default 0.02).
     - classes: Restrict replacements to these Unicode script classes (default ["LATIN","GREEK","CYRILLIC"]). Use "all" to allow any.
+    - banned_characters: Characters that must never appear as replacements.
     - seed: Optional seed if `rng` not provided.
     - rng: Optional RNG; overrides seed.
 
@@ -37,6 +42,7 @@ def swap_homoglyphs(
     num_replacements = int(len(confusable_chars) * replacement_rate)
     done = 0
     rng.shuffle(confusable_chars)
+    banned_set = set(banned_characters or ())
     for char in confusable_chars:
         if done >= num_replacements:
             break
@@ -45,6 +51,8 @@ def swap_homoglyphs(
         ]
         if classes != "all":
             options = [opt for opt in options if confusables.alias(opt) in classes]
+        if banned_set:
+            options = [opt for opt in options if opt not in banned_set]
         if not options:
             continue
         text = text.replace(char, rng.choice(options), 1)
@@ -60,6 +68,7 @@ class Mim1c(Glitchling):
         *,
         replacement_rate: float = 0.02,
         classes: list[str] | Literal["all"] | None = None,
+        banned_characters: Collection[str] | None = None,
         seed: int | None = None,
     ) -> None:
         super().__init__(
@@ -70,6 +79,7 @@ class Mim1c(Glitchling):
             seed=seed,
             replacement_rate=replacement_rate,
             classes=classes,
+            banned_characters=banned_characters,
         )
 
 

--- a/tests/test_parameter_effects.py
+++ b/tests/test_parameter_effects.py
@@ -18,6 +18,16 @@ def test_mim1c_replacement_rate_bounds(sample_text):
     assert changed <= int(len(alnum) * 0.02) + 2  # slack for discrete rounding
 
 
+def test_mim1c_respects_banned_characters():
+    m = mim1c.clone()
+    m.set_param("seed", 2)
+    m.set_param("replacement_rate", 1.0)
+    m.set_param("banned_characters", ["ａ"])
+
+    out = cast(str, m("a"))
+    assert out != "ａ"
+
+
 def test_reduple_rate_increases_tokens():
     text = "a b c d e f g h"
     reduple.set_param("seed", 5)


### PR DESCRIPTION
## Summary
- allow Mim1c and swap_homoglyphs to accept a banned_characters collection and filter replacement options
- document the new parameter across README, MONSTER_MANUAL, and docs/index
- add coverage ensuring Mim1c respects banned characters when corrupting text

## Testing
- PYTHONPATH=src pytest tests/test_parameter_effects.py


------
https://chatgpt.com/codex/tasks/task_e_68e0aca926c88332bb1a30e7de2fa0e4