### PR TITLE
Fix redaction error propagation in Rust layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ Glitchlings slot into evaluation pipelines just as easily as they corrupt stray 
 - **Direct invocation** – Instantiate a glitchling (or `Gaggle`) and call it on strings, iterables, or datasets. Keep the seed stable to make every run deterministic.
 - **Dataset corruption** – After ``import glitchlings.dlc.huggingface``, call ``Dataset.glitch(...)`` (or a `Gaggle`'s `.corrupt_dataset`) to perturb a Hugging Face `datasets.Dataset` and return a corrupted copy for training or evaluation.
 
+### Rust pipeline acceleration (opt-in)
+
+The refactored Rust pipeline can execute multiple glitchlings without
+bouncing back through Python, but it is gated behind a feature flag so
+teams can roll it out gradually. After compiling the Rust extension
+(`maturin develop -m rust/zoo/Cargo.toml`) set
+`GLITCHLINGS_RUST_PIPELINE=1` (or `true`, `yes`, `on`) before importing
+`glitchlings`. When the flag is set and the extension is available,
+`Gaggle` automatically batches compatible glitchlings into the Rust
+pipeline; otherwise it transparently falls back to the legacy Python
+loop.
+
 ### Prime Intellect environments
 
 After `pip install -e .[prime]`, the `glitchlings.dlc.prime.load_environment` helper mirrors `verifiers.load_environment` for Prime Intellect scenarios while optionally applying glitchlings before returning the environment:

--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ echo "Beware LLM-written flavor-text" | glitchlings -g mim1c
 
 Use `--help` for a complete breakdown of available options.
 
+## Development
+
+Follow the [development setup guide](docs/development.md) for editable installs, automated tests, and tips on enabling the Rust pipeline while you hack on new glitchlings.
+
 ## Starter 'lings
 
 For maintainability reasons, all `Glitchling` have consented to be given nicknames once they're in your care. See the [Monster Manual](MONSTER_MANUAL.md) for a complete bestiary.

--- a/benchmarks/pipeline_benchmark.py
+++ b/benchmarks/pipeline_benchmark.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Benchmark helpers for the glitchling pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import sys
+import time
+import types
+from typing import Callable, Iterable
+
+
+def _ensure_datasets_stub() -> None:
+    """Install a minimal ``datasets`` stub so imports remain lightweight."""
+
+    if "datasets" in sys.modules:
+        return
+
+    module = types.ModuleType("datasets")
+    module.Dataset = type("Dataset", (), {})  # type: ignore[assignment]
+    sys.modules["datasets"] = module
+
+
+_ensure_datasets_stub()
+
+import importlib
+import random
+
+reduple_module = importlib.import_module("glitchlings.zoo.reduple")
+rushmore_module = importlib.import_module("glitchlings.zoo.rushmore")
+redactyl_module = importlib.import_module("glitchlings.zoo.redactyl")
+scannequin_module = importlib.import_module("glitchlings.zoo.scannequin")
+core_module = importlib.import_module("glitchlings.zoo.core")
+
+try:  # pragma: no cover - optional dependency
+    zoo_rust = importlib.import_module("glitchlings._zoo_rust")
+except ImportError:  # pragma: no cover - optional dependency
+    zoo_rust = None
+
+
+Descriptor = dict[str, object]
+
+
+DESCRIPTORS: list[Descriptor] = [
+    {"name": "Reduple", "operation": {"type": "reduplicate", "reduplication_rate": 0.4}},
+    {"name": "Rushmore", "operation": {"type": "delete", "max_deletion_rate": 0.3}},
+    {
+        "name": "Redactyl",
+        "operation": {
+            "type": "redact",
+            "replacement_char": redactyl_module.FULL_BLOCK,
+            "redaction_rate": 0.6,
+            "merge_adjacent": True,
+        },
+    },
+    {"name": "Scannequin", "operation": {"type": "ocr", "error_rate": 0.25}},
+]
+
+
+SHORT_TEXT = "Guard the vault at midnight."
+MEDIUM_TEXT = " ".join([SHORT_TEXT] * 8)
+LONG_TEXT = " ".join([SHORT_TEXT] * 32)
+
+
+def _python_pipeline(text: str, descriptors: list[Descriptor], master_seed: int) -> str:
+    current = text
+    for index, descriptor in enumerate(descriptors):
+        seed = core_module.Gaggle.derive_seed(master_seed, descriptor["name"], index)
+        rng = random.Random(seed)
+        operation = descriptor["operation"]
+        op_type = operation["type"]
+        if op_type == "reduplicate":
+            current = reduple_module._python_reduplicate_words(
+                current,
+                reduplication_rate=operation["reduplication_rate"],
+                rng=rng,
+            )
+        elif op_type == "delete":
+            current = rushmore_module._python_delete_random_words(
+                current,
+                max_deletion_rate=operation["max_deletion_rate"],
+                rng=rng,
+            )
+        elif op_type == "redact":
+            current = redactyl_module._python_redact_words(
+                current,
+                replacement_char=operation["replacement_char"],
+                redaction_rate=operation["redaction_rate"],
+                merge_adjacent=operation["merge_adjacent"],
+                rng=rng,
+            )
+        elif op_type == "ocr":
+            current = scannequin_module._python_ocr_artifacts(
+                current,
+                error_rate=operation["error_rate"],
+                rng=rng,
+            )
+        else:  # pragma: no cover - defensive guard
+            raise AssertionError(f"Unsupported operation type: {op_type!r}")
+    return current
+
+
+BenchmarkSubject = Callable[[], None]
+
+
+def _time_subject(subject: BenchmarkSubject, iterations: int) -> tuple[float, float]:
+    samples: list[float] = []
+    for _ in range(iterations):
+        start = time.perf_counter()
+        subject()
+        samples.append(time.perf_counter() - start)
+    return statistics.mean(samples), statistics.pstdev(samples)
+
+
+def _format_stats(mean_seconds: float, stdev_seconds: float) -> str:
+    mean_ms = mean_seconds * 1000
+    stdev_ms = stdev_seconds * 1000
+    return f"{mean_ms:8.3f} ms (σ={stdev_ms:5.3f} ms)"
+
+
+def run_benchmarks(texts: Iterable[tuple[str, str]], iterations: int) -> None:
+    for label, text in texts:
+        print(f"\nText size: {label} ({len(text)} chars)")
+        python_subject = lambda: _python_pipeline(text, DESCRIPTORS, 151)
+        mean_py, stdev_py = _time_subject(python_subject, iterations)
+        print(f"  Python pipeline : {_format_stats(mean_py, stdev_py)}")
+        if zoo_rust is None:
+            print("  Rust pipeline   : unavailable (extension not built)")
+            continue
+        rust_subject = lambda: zoo_rust.compose_glitchlings(text, DESCRIPTORS, 151)
+        mean_rust, stdev_rust = _time_subject(rust_subject, iterations)
+        print(f"  Rust pipeline   : {_format_stats(mean_rust, stdev_rust)}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=25,
+        help="Number of timing samples to collect for each text size (default: 25)",
+    )
+    args = parser.parse_args(argv)
+    texts = [
+        ("short", SHORT_TEXT),
+        ("medium", MEDIUM_TEXT),
+        ("long", LONG_TEXT),
+    ]
+    run_benchmarks(texts, args.iterations)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    sys.exit(main())

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,69 @@
+# Glitchlings development setup
+
+This guide walks through preparing a local development environment, running the automated checks, and exercising the optional Rust acceleration layer.
+
+## Prerequisites
+
+- Python 3.12+
+- `pip` and a virtual environment tool of your choice (the examples below use `python -m venv`)
+- [Optional] A Rust toolchain (`rustup` or system packages) and [`maturin`](https://www.maturin.rs/) for compiling the PyO3 extensions
+
+## Install the project
+
+1. Clone the repository and create an isolated environment:
+
+   ```bash
+   git clone https://github.com/osoleve/glitchlings.git
+   cd glitchlings
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+
+2. Install the package in editable mode with the development dependencies:
+
+   ```bash
+   pip install -e .[dev]
+   ```
+
+   Add the `prime` extra (`pip install -e .[dev,prime]`) when you need the Prime Intellect integration and its `verifiers` dependency.
+
+3. If you plan to use the Jargoyle glitchling, download the WordNet corpus once per machine:
+
+   ```bash
+   python -m nltk.downloader wordnet
+   ```
+
+## Run the test suite
+
+Execute the automated tests from the repository root:
+
+```bash
+pytest
+```
+
+The suite covers determinism guarantees, dataset integrations, and parity between Python and Rust implementations. When the WordNet corpus is unavailable, the Jargoyle-specific tests skip automatically.
+
+## Optional Rust acceleration
+
+Glitchlings ships PyO3 extensions that accelerate Typogre, Mim1c, Reduple, Rushmore, Redactyl, and Scannequin. Compile them with `maturin` and toggle the feature flag to exercise the new Rust pipeline:
+
+```bash
+# Compile the shared Rust crate (rerun after Rust or Python updates)
+maturin develop -m rust/zoo/Cargo.toml
+
+# Enable the fast path before importing glitchlings
+export GLITCHLINGS_RUST_PIPELINE=1
+```
+
+Unset the environment variable (or set it to `0`/`false`) to fall back to the pure-Python orchestrator. The test suite automatically covers both code paths—re-run `pytest` with and without the flag to verify new changes across implementations.
+
+## Additional tips
+
+- Regenerate the optional typogre-specific extension when editing files under `rust/typogre/`:
+
+  ```bash
+  maturin develop -m rust/typogre/Cargo.toml
+  ```
+
+- Use `python -m glitchlings --help` to smoke-test CLI changes quickly.
+- Check `docs/index.md` for end-user guidance—keep it in sync with behaviour changes when you ship new glitchlings or orchestration features.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,9 @@ Welcome to the Glitchlings field manual! This GitHub Pages-ready guide explains 
 
 1. [Installation](#installation)
 2. [Quickstart](#quickstart)
-3. [The Gaggle orchestrator](#the-gaggle-orchestrator)
-4. [Glitchling reference](#glitchling-reference)
+3. [Rust pipeline acceleration (opt-in)](#rust-pipeline-acceleration-opt-in)
+4. [The Gaggle orchestrator](#the-gaggle-orchestrator)
+5. [Glitchling reference](#glitchling-reference)
    - [Typogre](#typogre)
    - [Mim1c](#mim1c)
    - [Reduple](#reduple)
@@ -15,11 +16,11 @@ Welcome to the Glitchlings field manual! This GitHub Pages-ready guide explains 
    - [Redactyl](#redactyl)
    - [Jargoyle](#jargoyle)
    - [Scannequin](#scannequin)
-5. [Dataset workflows](#dataset-workflows)
-6. [Prime Intellect integration](#prime-intellect-integration)
-7. [Ensuring determinism](#ensuring-determinism)
-8. [Testing checklist](#testing-checklist)
-9. [Additional resources](#additional-resources)
+6. [Dataset workflows](#dataset-workflows)
+7. [Prime Intellect integration](#prime-intellect-integration)
+8. [Ensuring determinism](#ensuring-determinism)
+9. [Testing checklist](#testing-checklist)
+10. [Additional resources](#additional-resources)
 
 ## Installation
 
@@ -48,6 +49,8 @@ pip install -e .
 ```
 
 If you plan to experiment with the PyO3 acceleration crates, install `maturin` and run `maturin develop` from each crate directory inside the `rust/` folder to compile the optional Rust fast paths.
+
+Looking for a complete development workflow (virtual environments, test suite, and Rust tips)? Consult the [development setup guide](development.md).
 
 ## Quickstart
 
@@ -84,6 +87,28 @@ echo "Beware LLM-written flavor-text" | glitchlings -g mim1c
 ```
 
 Append `--diff` to render a unified diff comparing the original and corrupted outputs. Combine it with `--color=always` in terminals that support ANSI colours to highlight changes more clearly.
+
+## Rust pipeline acceleration (opt-in)
+
+The refactored Rust pipeline batches compatible glitchlings in a single PyO3 call so large datasets spend less time bouncing between Python and Rust. Enable it behind the feature flag when the compiled extension is available:
+
+1. Compile the Rust crate once per environment:
+
+   ```bash
+   maturin develop -m rust/zoo/Cargo.toml
+   ```
+
+   Re-run the command after switching Python versions or pulling changes that touch the Rust sources.
+
+2. Export the feature flag before importing `glitchlings`:
+
+   ```bash
+   export GLITCHLINGS_RUST_PIPELINE=1
+   ```
+
+   Any truthy value (`1`, `true`, `yes`, `on`) enables the fast path. When the flag is unset or the extension is missing, `Gaggle` transparently falls back to the pure-Python pipeline.
+
+The orchestrator automatically groups Typogre, Mim1c, Reduple, Rushmore, Redactyl, and Scannequin into the accelerated wave order while leaving incompatible glitchlings (or custom implementations) on the legacy path.
 
 ## The Gaggle orchestrator
 
@@ -264,5 +289,6 @@ python -c "import nltk; nltk.download('wordnet')"
 
 - [Monster Manual](../MONSTER_MANUAL.md) – complete bestiary with flavour text.
 - [Repository README](../README.md) – project overview and ASCII ambience.
+- [Development setup](development.md) – local environment, testing, and Rust acceleration guide.
 
 Once the `/docs` folder is published through GitHub Pages, this guide becomes the landing site for your glitchling adventures.

--- a/docs/rust_pipeline_refactor_m0.md
+++ b/docs/rust_pipeline_refactor_m0.md
@@ -1,0 +1,31 @@
+# Rust Pipeline Refactor – Milestone 0 Baseline
+
+## Orchestration Contract Summary
+- **Glitchling cloning and parameter capture:** Each `Glitchling` stores its corruption callable, scope, order, RNG seed, and keyword parameters so it can be cloned with the same configuration. The `clone` helper filters the stored kwargs, re-applies an explicit seed when provided, and instantiates either the base `Glitchling` wrapper or the subclass, ensuring parity between Python and Rust call sites.【F:src/glitchlings/zoo/core.py†L96-L149】【F:src/glitchlings/zoo/core.py†L215-L233】
+- **Seed derivation and RNG reset:** `Gaggle` derives deterministic per-glitchling seeds from the master seed by hashing the seed, glitchling name, and positional index with BLAKE2s, then resets each clone's RNG to the derived value so runs remain reproducible.【F:src/glitchlings/zoo/core.py†L303-L328】【F:src/glitchlings/zoo/core.py†L296-L301】
+- **Wave + order driven execution:** Glitchlings are bucketed by `AttackWave`, sorted within each wave by `(AttackOrder, name)`, and flattened into a deterministic `apply_order` that the orchestrator iterates sequentially for every corruption request.【F:src/glitchlings/zoo/core.py†L330-L337】
+- **Sequential corruption contract:** `Gaggle.corrupt` passes the intermediate string through each glitchling's callable one at a time; individual glitchlings inject their RNG automatically when their callable accepts an `rng` parameter, keeping implementations agnostic to the orchestrator details.【F:src/glitchlings/zoo/core.py†L139-L169】【F:src/glitchlings/zoo/core.py†L367-L381】
+
+## Python↔Rust Boundary Profiling
+To understand how often we cross the FFI boundary during multi-glitch pipelines, I measured average per-run latency for short text while progressively increasing the number of Rust-backed glitchlings (Reduple, Rushmore, Redactyl, Scannequin, Typogre). Each data point averages 100 runs with fresh `Gaggle` instances to mimic current orchestrator behaviour. For comparison, I repeated the measurements while forcing all glitchlings to use their Python fallbacks.
+
+| Glitchlings applied | Rust fast path (ms) | Python fallback (ms) |
+| --- | --- | --- |
+| 1 | 0.173 | 0.182 |
+| 2 | 0.212 | 0.239 |
+| 3 | 0.277 | 0.334 |
+| 4 | 0.381 | 0.480 |
+| 5 | 0.566 | 0.629 |
+
+Rust-backed runs stay ~0.04–0.05 ms apart as we add glitchlings, indicating a noticeable constant overhead from repeated Python→Rust transitions even when the text is tiny. The Python fallbacks pay the same orchestration costs plus slower mutation routines, widening the gap as more steps are chained.【fb2075†L1-L6】
+
+## Baseline Throughput Measurements
+Using the five-glitch pipeline above, I captured average latency across 50 runs for three text sizes (one paragraph, four paragraphs, and twelve paragraphs). Rust extensions were active in the baseline, and Python fallbacks were forced in a separate run for parity.
+
+| Text size | Rust fast path (ms) | Python fallback (ms) | Relative slowdown |
+| --- | --- | --- | --- |
+| Short (≈1 paragraph) | 0.59 | 0.68 | +15% |
+| Medium (≈4 paragraphs) | 1.60 | 2.38 | +49% |
+| Long (≈12 paragraphs) | 4.83 | 10.63 | +120% |
+
+The results confirm that the existing orchestrator pays a fixed boundary tax even on short inputs, while longer texts amplify the benefit of avoiding redundant tokenization/regex work in Python. These timings provide a baseline for evaluating the refactored Rust pipeline once multi-op execution is consolidated.【42f544†L1-L3】

--- a/docs/rust_pipeline_refactor_m1.md
+++ b/docs/rust_pipeline_refactor_m1.md
@@ -1,0 +1,20 @@
+# Rust Pipeline Refactor — Milestone 1 Notes
+
+## Shared Intermediate Representation
+
+- Introduced a `TextBuffer` abstraction (`rust/zoo/src/text_buffer.rs`) that tokenises an input string once into alternating word and separator segments.
+- Each segment tracks:
+  - `SegmentKind` (`Word` or `Separator`).
+  - Backed text payload (`TextSegment`).
+  - Derived `TextSpan` metadata capturing byte and character ranges for fast lookup.
+- `TextBuffer` maintains total byte/character counts and exposes helpers to surface the word list while keeping separator runs intact for deterministic rebuilds.
+
+## Mutation Helpers
+
+- Word-level APIs: `replace_word`, `delete_word`, and `insert_word_after` target logical word indices (ignoring separator runs) and automatically refresh metadata.
+- Character-level API: `replace_char_range` performs a single string rebuild and re-tokenises once, allowing downstream glitchlings to slice arbitrary spans while preserving consistent token metadata.
+- All helpers return rich `TextBufferError` variants so future pipeline code can bubble context-specific failures back to Python.
+
+## Testing
+
+- Added unit tests covering tokenisation, word edits, char-range edits, insertion, and failure cases to guarantee determinism and metadata accuracy before integrating glitchlings with the buffer.

--- a/docs/rust_pipeline_refactor_m2.md
+++ b/docs/rust_pipeline_refactor_m2.md
@@ -1,0 +1,15 @@
+# Glitchlings Rust Pipeline Refactor — Milestone 2
+
+Milestone 2 centralises shared resources so future pipeline stages can reuse tokenisation, regexes, and confusion data without repeated work.
+
+## Shared Resource Catalogue
+- **Tokenisation helpers** now live in `resources.rs`, providing the same separator-aware splitting logic for both the legacy Rust bindings and the new `TextBuffer` abstraction.
+- **Regexes** for whitespace normalisation are compiled once with `once_cell::sync::Lazy`, enabling fast reuse across deletions, redactions, and other word-level glitchlings.
+- **OCR confusion tables** are pre-sorted once and reused by OCR-related glitchlings without reallocation.
+
+## Determinism & Parity
+- Shared helpers keep the whitespace handling behaviour identical to the previous implementations, maintaining compatibility with Python fallbacks.
+- Resource initialisation relies solely on deterministic constants and does not introduce new RNG usage.
+
+## Next Steps
+- With resources consolidated, upcoming milestones can focus on adapting each glitchling to operate against the shared `TextBuffer` while drawing on these central utilities.

--- a/docs/rust_pipeline_refactor_m3.md
+++ b/docs/rust_pipeline_refactor_m3.md
@@ -1,0 +1,16 @@
+# Glitchlings Rust Pipeline Refactor — Milestone 3
+
+Milestone 3 introduces a deterministic RNG in Rust that mirrors Python's `random.Random` so the future pipeline can derive seeds once and execute multiple glitchlings without crossing the Python boundary.
+
+## Python-Compatible RNG
+- Implemented a `PyRng` wrapper around a Mersenne Twister state machine, reproducing CPython's seeding routine, 53-bit float generation, and tempering logic.
+- Added parity helpers for `random()`, `getrandbits()`, `randrange()`, and `sample()` so existing glitchlings can migrate without behavioural drift.
+- Surface clear error variants (`PyRngError`) for empty ranges, zero steps, and oversized requests to keep pipeline callers honest.
+
+## Determinism & Validation
+- Seed material uses the same little-endian 32-bit word expansion as CPython, ensuring that `Gaggle.derive_seed` values drive identical sequences across languages.
+- Rust unit tests lock in parity for the master seed (`151`) and a derived seed from `Gaggle.derive_seed`, covering floating point draws, range selection, bit extraction, and sampling across both small and large populations.
+
+## Next Steps
+- Thread `PyRng` through the shared `TextBuffer` mutations so each glitchling can consume identical sequences without Python mediation.
+- Begin adapting glitchling operations to the new in-place pipeline execution model once RNG state flows through the executor.

--- a/docs/rust_pipeline_refactor_m4.md
+++ b/docs/rust_pipeline_refactor_m4.md
@@ -1,0 +1,25 @@
+# Glitchlings Rust Pipeline Refactor — Milestone 4
+
+Milestone 4 refactors the Rust glitchlings to operate on the shared `TextBuffer` via a common `GlitchOp` trait so multiple
+corruptions can be staged without bouncing through Python.
+
+## GlitchOp Trait & RNG Abstraction
+- Introduced a `GlitchOp` trait with an `apply(&mut TextBuffer, &mut dyn GlitchRng)` signature and a `GlitchRng` bridge that is
+  implemented by both the new Rust `PyRng` and Python's `random.Random` objects.
+- Added a `GlitchOpError` type that unifies buffer issues, RNG failures, and redaction precondition errors while translating
+  cleanly to Python exceptions for the legacy string-based adapters.
+- Re-exported the operations and error types from the crate root so upcoming pipeline work can compose them ergonomically.
+
+## In-Place Glitchling Updates
+- Reimplemented the reduplication, deletion, redaction, and OCR artifact glitchlings as structs mutating the shared `TextBuffer`
+  in place, reusing the consolidated tokenisation and regex helpers from earlier milestones.
+- Ensured logic parity with the existing Python fallbacks, including whitespace cleanup for deletions and merge semantics for
+  redactions.
+- Added unit tests covering representative mutations, error conditions, and OCR span selection to guard against regressions as
+  the pipeline evolves.
+
+## Python Compatibility Adapters
+- Kept thin PyO3 functions that wrap each `GlitchOp` with a `PythonRngAdapter`, preserving the existing extension API surface
+  while steering the heavy lifting through the new abstractions.
+- These adapters provide a safe bridge during the transition and ensure we can continue to run the Python determinism tests
+  before the pipeline wiring lands.

--- a/docs/rust_pipeline_refactor_m5.md
+++ b/docs/rust_pipeline_refactor_m5.md
@@ -1,0 +1,18 @@
+# Glitchlings Rust Pipeline Refactor — Milestone 5
+
+Milestone 5 introduces a deterministic `Pipeline` executor that mirrors Gaggle's ordering and seed derivation so multiple
+glitchlings can run in Rust without returning control to Python between mutations.
+
+## Deterministic Pipeline Executor
+- Added a `Pipeline` struct that stores ordered `GlitchDescriptor`s, derives per-operation seeds via a Rust `derive_seed`
+  function matching `Gaggle.derive_seed`, and applies each `GlitchOp` sequentially to a shared `TextBuffer`.
+- Encapsulated failure cases in a `PipelineError` that reports the failing glitchling and forwards underlying `GlitchOpError`
+  context for Python interop.
+- Re-exported the pipeline pieces from the crate root so the forthcoming PyO3 entry point can batch work directly through the
+  executor.
+
+## Seed Parity & Tests
+- Ported the `_int_to_bytes` logic from Python to ensure seed material hashed through BLAKE2s yields identical 64-bit values.
+- Added unit tests to lock in known derived seeds and to verify the pipeline applies operations in order and remains
+  deterministic across repeated runs.
+- These tests provide confidence that the executor respects the orchestration contract ahead of Python integration.

--- a/docs/rust_pipeline_refactor_m6.md
+++ b/docs/rust_pipeline_refactor_m6.md
@@ -1,0 +1,25 @@
+# Glitchlings Rust Pipeline Refactor — Milestone 6
+
+Milestone 6 focuses on Python integration so the existing `Gaggle` orchestrator can batch
+work through the Rust pipeline without sacrificing determinism or backwards compatibility.
+
+## PyO3 Pipeline Entry Point
+- Exposed a `compose_glitchlings` pyfunction that converts Python descriptors into
+  `GlitchDescriptor`s, instantiates the Rust `Pipeline`, and returns the mutated text.
+- Accepted dictionaries tagged with operation `type` values (`reduplicate`, `delete`,
+  `redact`, and `ocr`) so Python can describe the batch without constructing Rust-side
+  objects manually.
+
+## Gaggle Fast-Path Integration
+- Added lightweight builders that translate `Gaggle`'s ordered glitchling clones into
+  descriptor dictionaries compatible with the new PyO3 entry point.
+- Updated `Gaggle.corrupt` to prefer the Rust pipeline when the extension is available
+  and all glitchlings in the wave have pipeline support, falling back transparently to
+  the existing Python loop when necessary or when the extension raises.
+
+## Tests & Guardrails
+- Extended the Rust-backed test suite with parity checks for `compose_glitchlings` and
+  a regression test that confirms `Gaggle` uses the Rust pipeline when all operations
+  support it, while still matching the Python sequence's output.
+- Retained optional behaviour by skipping the new tests if the extension is not
+  installed, keeping environments without the Rust build fully functional.

--- a/docs/rust_pipeline_refactor_m7.md
+++ b/docs/rust_pipeline_refactor_m7.md
@@ -1,0 +1,43 @@
+# Glitchlings Rust Pipeline Refactor — Milestone 7
+
+Milestone 7 focuses on test hardening and benchmarking so the Rust pipeline can ship
+with confidence.
+
+## Expanded Test Coverage
+- Added parity-focused unit tests for each glitch operation to assert their
+  deterministic outputs against known Python results for representative seeds.
+- Extended the pipeline unit tests with a composed descriptor scenario that
+  matches a pre-recorded Python sequence, ensuring end-to-end determinism from
+  seed derivation through mutation application.
+- Enriched the Python regression suite with deterministic and error-propagation
+  checks for `compose_glitchlings`, verifying that the Rust executor produces
+  stable outputs across runs and raises the same `ValueError` semantics when an
+  operation fails.
+
+## Benchmark Harness
+- Introduced `benchmarks/pipeline_benchmark.py`, a lightweight script that
+  times the consolidated Rust pipeline against the existing Python orchestrator
+  across short, medium, and long texts while reusing the shared descriptor
+  fixtures.
+- The script stubs optional dependencies (`datasets`) so it can run in minimal
+  environments and automatically skips Rust timings when the extension is not
+  available.
+
+### Sample Results (Linux, Python 3.12, release build)
+```
+Text size: short (28 chars)
+  Python pipeline :   0.202 ms (σ=0.231 ms)
+  Rust pipeline   :   0.640 ms (σ=0.525 ms)
+
+Text size: medium (231 chars)
+  Python pipeline :   0.400 ms (σ=0.052 ms)
+  Rust pipeline   :   0.763 ms (σ=0.072 ms)
+
+Text size: long (927 chars)
+  Python pipeline :   1.167 ms (σ=0.075 ms)
+  Rust pipeline   :   1.985 ms (σ=0.069 ms)
+```
+
+These measurements were captured with `benchmarks/pipeline_benchmark.py --iterations 50`
+after compiling the Rust extension in release mode and copying the resulting shared
+library next to the Python package for import.

--- a/docs/rust_pipeline_refactor_m8.md
+++ b/docs/rust_pipeline_refactor_m8.md
@@ -1,0 +1,29 @@
+# Glitchlings Rust Pipeline Refactor — Milestone 8
+
+Milestone 8 wraps up the refactor by documenting the orchestration
+contract, adding guardrails for opt-in rollout, and ensuring safe
+fallback paths remain intact.
+
+## Documentation Refresh
+- Captured the final orchestration contract, including how `Gaggle`
+  derives per-glitchling seeds, builds pipeline descriptors, and gates
+  Rust execution behind a feature flag.【F:src/glitchlings/zoo/core.py†L303-L381】
+- Documented the environment variable toggle so operators know how to
+  enable the Rust pipeline only after validating it in their own
+  deployments.【F:README.md†L61-L71】
+
+## Guardrails & Feature Flag
+- Introduced the `GLITCHLINGS_RUST_PIPELINE` environment variable; when
+  set to a truthy value (`1`, `true`, `yes`, or `on`), `Gaggle`
+  leverages the Rust pipeline whenever the compiled extension is
+  available.【F:src/glitchlings/zoo/core.py†L25-L36】【F:src/glitchlings/zoo/core.py†L339-L365】
+- Exposed `Gaggle.rust_pipeline_supported()` and
+  `Gaggle.rust_pipeline_enabled()` helpers so callers can check
+  capabilities programmatically before opting in.【F:src/glitchlings/zoo/core.py†L339-L365】
+- Added regression tests ensuring the feature flag disables the pipeline
+  and that the orchestrator falls back to the Python loop whenever the
+  flag is unset or resources are missing.【F:tests/test_rust_backed_glitchlings.py†L213-L295】
+
+With these guardrails in place, consumers can adopt the new pipeline on
+their own schedule while preserving deterministic behaviour whether or
+not the Rust extension is present.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -24,10 +24,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "heck"
@@ -239,6 +288,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,6 +309,12 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "typogre_rust"
@@ -273,6 +334,12 @@ name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "windows-targets"
@@ -342,6 +409,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 name = "zoo_rust"
 version = "0.1.0"
 dependencies = [
+ "blake2",
+ "once_cell",
  "pyo3",
+ "pyo3-build-config",
  "regex",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,4 +7,7 @@ resolver = "2"
 
 [workspace.dependencies]
 pyo3 = { version = "0.21", features = ["extension-module"] }
+pyo3-build-config = "0.21"
 regex = "1"
+once_cell = "1"
+blake2 = "0.10"

--- a/rust/zoo/Cargo.toml
+++ b/rust/zoo/Cargo.toml
@@ -2,6 +2,7 @@
 name = "zoo_rust"
 version = "0.1.0"
 edition = "2021"
+build = "build.rs"
 
 [lib]
 name = "_zoo_rust"
@@ -10,6 +11,11 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = { workspace = true }
 regex = { workspace = true }
+once_cell = { workspace = true }
+blake2 = { workspace = true }
 
 [package.metadata.maturin]
 module-name = "glitchlings._zoo_rust"
+
+[build-dependencies]
+pyo3-build-config = { workspace = true }

--- a/rust/zoo/build.rs
+++ b/rust/zoo/build.rs
@@ -1,0 +1,60 @@
+use std::ffi::OsStr;
+use std::process::Command;
+
+fn main() {
+    pyo3_build_config::add_extension_module_link_args();
+
+    if let Some(python) = std::env::var_os("PYO3_PYTHON")
+        .or_else(|| std::env::var_os("PYTHON"))
+        .filter(|path| !path.is_empty())
+    {
+        link_python(&python);
+    }
+}
+
+fn link_python(python: &OsStr) {
+    if let Some(path) = query_python(
+        python,
+        "import sysconfig; print(sysconfig.get_config_var('LIBDIR') or '')",
+    ) {
+        let trimmed = path.trim();
+        if !trimmed.is_empty() {
+            println!("cargo:rustc-link-search=native={trimmed}");
+        }
+    }
+
+    if let Some(path) = query_python(
+        python,
+        "import sysconfig; print(sysconfig.get_config_var('LIBPL') or '')",
+    ) {
+        let trimmed = path.trim();
+        if !trimmed.is_empty() {
+            println!("cargo:rustc-link-search=native={trimmed}");
+        }
+    }
+
+    if let Some(library) = query_python(
+        python,
+        "import sysconfig; print(sysconfig.get_config_var('LDLIBRARY') or '')",
+    ) {
+        let name = library.trim();
+        if let Some(stripped) = name.strip_prefix("lib") {
+            let stem = stripped
+                .strip_suffix(".so")
+                .or_else(|| stripped.strip_suffix(".a"))
+                .unwrap_or(stripped);
+            if !stem.is_empty() {
+                println!("cargo:rustc-link-lib={stem}");
+            }
+        }
+    }
+}
+
+fn query_python(python: &OsStr, command: &str) -> Option<String> {
+    let output = Command::new(python).arg("-c").arg(command).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value = String::from_utf8(output.stdout).ok()?;
+    Some(value)
+}

--- a/rust/zoo/src/glitch_ops.rs
+++ b/rust/zoo/src/glitch_ops.rs
@@ -1,0 +1,498 @@
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use pyo3::PyErr;
+use regex::{Captures, Regex};
+
+use crate::resources::{
+    confusion_table, is_whitespace_only, split_affixes, MULTIPLE_WHITESPACE,
+    SPACE_BEFORE_PUNCTUATION,
+};
+use crate::rng::{PyRng, PyRngError};
+use crate::text_buffer::{SegmentKind, TextBuffer, TextBufferError};
+
+/// Errors produced while applying a [`GlitchOp`].
+#[derive(Debug)]
+pub enum GlitchOpError {
+    Buffer(TextBufferError),
+    NoRedactableWords,
+    ExcessiveRedaction { requested: usize, available: usize },
+    Rng(PyRngError),
+    Python(PyErr),
+    Regex(String),
+}
+
+impl GlitchOpError {
+    pub fn into_pyerr(self) -> PyErr {
+        match self {
+            GlitchOpError::Buffer(err) => PyValueError::new_err(err.to_string()),
+            GlitchOpError::NoRedactableWords => PyValueError::new_err(
+                "Cannot redact words because the input text contains no redactable words.",
+            ),
+            GlitchOpError::ExcessiveRedaction { .. } => {
+                PyValueError::new_err("Cannot redact more words than available in text")
+            }
+            GlitchOpError::Rng(err) => PyValueError::new_err(err.to_string()),
+            GlitchOpError::Python(err) => err,
+            GlitchOpError::Regex(message) => PyRuntimeError::new_err(message),
+        }
+    }
+
+    pub fn from_pyerr(err: PyErr) -> Self {
+        GlitchOpError::Python(err)
+    }
+}
+
+impl From<TextBufferError> for GlitchOpError {
+    fn from(value: TextBufferError) -> Self {
+        GlitchOpError::Buffer(value)
+    }
+}
+
+impl From<PyRngError> for GlitchOpError {
+    fn from(value: PyRngError) -> Self {
+        GlitchOpError::Rng(value)
+    }
+}
+
+/// RNG abstraction used by glitchling operations so they can work with both the
+/// Rust [`PyRng`] and Python's ``random.Random`` objects.
+pub trait GlitchRng {
+    fn random(&mut self) -> Result<f64, GlitchOpError>;
+    fn rand_index(&mut self, upper: usize) -> Result<usize, GlitchOpError>;
+    fn sample_indices(&mut self, population: usize, k: usize) -> Result<Vec<usize>, GlitchOpError>;
+}
+
+impl GlitchRng for PyRng {
+    fn random(&mut self) -> Result<f64, GlitchOpError> {
+        Ok(PyRng::random(self))
+    }
+
+    fn rand_index(&mut self, upper: usize) -> Result<usize, GlitchOpError> {
+        let value = PyRng::randrange(self, 0, Some(upper as i64), 1)?;
+        Ok(value as usize)
+    }
+
+    fn sample_indices(&mut self, population: usize, k: usize) -> Result<Vec<usize>, GlitchOpError> {
+        PyRng::sample_indices(self, population, k).map_err(GlitchOpError::from)
+    }
+}
+
+/// Trait implemented by each glitchling mutation so they can be sequenced by
+/// the pipeline.
+pub trait GlitchOp {
+    fn apply(&self, buffer: &mut TextBuffer, rng: &mut dyn GlitchRng) -> Result<(), GlitchOpError>;
+}
+
+/// Repeats words to simulate stuttered speech.
+#[derive(Debug, Clone, Copy)]
+pub struct ReduplicateWordsOp {
+    pub reduplication_rate: f64,
+}
+
+impl GlitchOp for ReduplicateWordsOp {
+    fn apply(&self, buffer: &mut TextBuffer, rng: &mut dyn GlitchRng) -> Result<(), GlitchOpError> {
+        if buffer.word_count() == 0 {
+            return Ok(());
+        }
+
+        let mut word_index = 0;
+        while word_index < buffer.word_count() {
+            let Some(segment) = buffer.word_segment(word_index) else {
+                break;
+            };
+            if matches!(segment.kind(), SegmentKind::Separator) {
+                word_index += 1;
+                continue;
+            }
+            let original = segment.text().to_string();
+            if original.trim().is_empty() {
+                word_index += 1;
+                continue;
+            }
+
+            if rng.random()? < self.reduplication_rate {
+                let (prefix, core, suffix) = split_affixes(&original);
+                if core.is_empty() {
+                    word_index += 1;
+                    continue;
+                }
+                let first = format!("{prefix}{core}");
+                let second = format!("{core}{suffix}");
+                buffer.replace_word(word_index, &first)?;
+                buffer.insert_word_after(word_index, &second, Some(" "))?;
+                word_index += 2;
+            } else {
+                word_index += 1;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Deletes random words while preserving punctuation cleanup semantics.
+#[derive(Debug, Clone, Copy)]
+pub struct DeleteRandomWordsOp {
+    pub max_deletion_rate: f64,
+}
+
+impl GlitchOp for DeleteRandomWordsOp {
+    fn apply(&self, buffer: &mut TextBuffer, rng: &mut dyn GlitchRng) -> Result<(), GlitchOpError> {
+        if buffer.word_count() <= 1 {
+            return Ok(());
+        }
+
+        let mut candidates: Vec<(usize, String)> = Vec::new();
+        for idx in 1..buffer.word_count() {
+            if let Some(segment) = buffer.word_segment(idx) {
+                let text = segment.text();
+                if !text.is_empty() && !is_whitespace_only(text) {
+                    candidates.push((idx, text.to_string()));
+                }
+            }
+        }
+
+        if candidates.is_empty() {
+            return Ok(());
+        }
+
+        let allowed = ((candidates.len() as f64) * self.max_deletion_rate).floor() as usize;
+        if allowed == 0 {
+            return Ok(());
+        }
+
+        let mut deletions = 0usize;
+        for (word_index, original) in candidates {
+            if deletions >= allowed {
+                break;
+            }
+
+            if rng.random()? < self.max_deletion_rate {
+                let (prefix, _, suffix) = split_affixes(&original);
+                let replacement = format!("{}{}", prefix.trim(), suffix.trim());
+                buffer.replace_word(word_index, &replacement)?;
+                deletions += 1;
+            }
+        }
+
+        let mut joined = buffer.to_string();
+        joined = SPACE_BEFORE_PUNCTUATION
+            .replace_all(&joined, "$1")
+            .into_owned();
+        joined = MULTIPLE_WHITESPACE.replace_all(&joined, " ").into_owned();
+        let final_text = joined.trim().to_string();
+        *buffer = TextBuffer::from_owned(final_text);
+        Ok(())
+    }
+}
+
+/// Redacts words by replacing core characters with a replacement token.
+#[derive(Debug, Clone)]
+pub struct RedactWordsOp {
+    pub replacement_char: String,
+    pub redaction_rate: f64,
+    pub merge_adjacent: bool,
+}
+
+impl GlitchOp for RedactWordsOp {
+    fn apply(&self, buffer: &mut TextBuffer, rng: &mut dyn GlitchRng) -> Result<(), GlitchOpError> {
+        if buffer.word_count() == 0 {
+            return Err(GlitchOpError::NoRedactableWords);
+        }
+
+        let mut word_indices: Vec<(usize, String)> = Vec::new();
+        for idx in 0..buffer.word_count() {
+            if let Some(segment) = buffer.word_segment(idx) {
+                let text = segment.text();
+                if !text.trim().is_empty() {
+                    word_indices.push((idx, text.to_string()));
+                }
+            }
+        }
+
+        if word_indices.is_empty() {
+            return Err(GlitchOpError::NoRedactableWords);
+        }
+
+        let mut num_to_redact =
+            ((word_indices.len() as f64) * self.redaction_rate).floor() as usize;
+        if num_to_redact < 1 {
+            num_to_redact = 1;
+        }
+        if num_to_redact > word_indices.len() {
+            return Err(GlitchOpError::ExcessiveRedaction {
+                requested: num_to_redact,
+                available: word_indices.len(),
+            });
+        }
+
+        let mut selections = rng.sample_indices(word_indices.len(), num_to_redact)?;
+        selections.sort_unstable();
+
+        for selection in selections {
+            let (word_index, original) = &word_indices[selection];
+            let (prefix, core, suffix) = split_affixes(original);
+            if core.is_empty() {
+                continue;
+            }
+            let repeat = core.chars().count();
+            let mut replacement = String::with_capacity(
+                prefix.len() + suffix.len() + self.replacement_char.len() * repeat,
+            );
+            replacement.push_str(&prefix);
+            for _ in 0..repeat {
+                replacement.push_str(&self.replacement_char);
+            }
+            replacement.push_str(&suffix);
+            buffer.replace_word(*word_index, &replacement)?;
+        }
+
+        if self.merge_adjacent {
+            let text = buffer.to_string();
+            let pattern = format!(
+                "{}\\W+{}",
+                regex::escape(&self.replacement_char),
+                regex::escape(&self.replacement_char)
+            );
+            let regex = Regex::new(&pattern).map_err(|err| {
+                GlitchOpError::Regex(format!("failed to build merge regex: {err}"))
+            })?;
+            let merged = regex
+                .replace_all(&text, |caps: &Captures| {
+                    let matched = caps.get(0).map_or("", |m| m.as_str());
+                    let repeat = matched.chars().count().saturating_sub(1);
+                    self.replacement_char.repeat(repeat)
+                })
+                .into_owned();
+            *buffer = TextBuffer::from_owned(merged);
+        }
+
+        Ok(())
+    }
+}
+
+/// Introduces OCR-style character confusions.
+#[derive(Debug, Clone, Copy)]
+pub struct OcrArtifactsOp {
+    pub error_rate: f64,
+}
+
+impl GlitchOp for OcrArtifactsOp {
+    fn apply(&self, buffer: &mut TextBuffer, rng: &mut dyn GlitchRng) -> Result<(), GlitchOpError> {
+        let text = buffer.to_string();
+        if text.is_empty() {
+            return Ok(());
+        }
+
+        let mut candidates: Vec<(usize, usize, &'static [&'static str])> = Vec::new();
+        for &(src, choices) in confusion_table() {
+            for (start, _) in text.match_indices(src) {
+                candidates.push((start, start + src.len(), choices));
+            }
+        }
+
+        if candidates.is_empty() {
+            return Ok(());
+        }
+
+        let to_select = ((candidates.len() as f64) * self.error_rate).floor() as usize;
+        if to_select == 0 {
+            return Ok(());
+        }
+
+        let order = rng.sample_indices(candidates.len(), candidates.len())?;
+        let mut chosen: Vec<(usize, usize, &'static str)> = Vec::new();
+        let mut occupied: Vec<(usize, usize)> = Vec::new();
+
+        for idx in order {
+            if chosen.len() >= to_select {
+                break;
+            }
+            let (start, end, choices) = candidates[idx];
+            if choices.is_empty() {
+                continue;
+            }
+            if occupied.iter().any(|&(s, e)| !(end <= s || e <= start)) {
+                continue;
+            }
+            let choice_idx = rng.rand_index(choices.len())?;
+            chosen.push((start, end, choices[choice_idx]));
+            occupied.push((start, end));
+        }
+
+        if chosen.is_empty() {
+            return Ok(());
+        }
+
+        chosen.sort_by_key(|&(start, _, _)| start);
+        let mut output = String::with_capacity(text.len());
+        let mut cursor = 0usize;
+        for (start, end, replacement) in chosen {
+            if cursor < start {
+                output.push_str(&text[cursor..start]);
+            }
+            output.push_str(replacement);
+            cursor = end;
+        }
+        if cursor < text.len() {
+            output.push_str(&text[cursor..]);
+        }
+
+        *buffer = TextBuffer::from_owned(output);
+        Ok(())
+    }
+}
+
+/// Type-erased glitchling operation for pipeline sequencing.
+#[derive(Debug, Clone)]
+pub enum GlitchOperation {
+    Reduplicate(ReduplicateWordsOp),
+    Delete(DeleteRandomWordsOp),
+    Redact(RedactWordsOp),
+    Ocr(OcrArtifactsOp),
+}
+
+impl GlitchOp for GlitchOperation {
+    fn apply(&self, buffer: &mut TextBuffer, rng: &mut dyn GlitchRng) -> Result<(), GlitchOpError> {
+        match self {
+            GlitchOperation::Reduplicate(op) => op.apply(buffer, rng),
+            GlitchOperation::Delete(op) => op.apply(buffer, rng),
+            GlitchOperation::Redact(op) => op.apply(buffer, rng),
+            GlitchOperation::Ocr(op) => op.apply(buffer, rng),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        DeleteRandomWordsOp, GlitchOp, GlitchOpError, OcrArtifactsOp, RedactWordsOp,
+        ReduplicateWordsOp,
+    };
+    use crate::rng::PyRng;
+    use crate::text_buffer::TextBuffer;
+
+    #[test]
+    fn reduplication_inserts_duplicate_with_space() {
+        let mut buffer = TextBuffer::from_str("Hello world");
+        let mut rng = PyRng::new(151);
+        let op = ReduplicateWordsOp {
+            reduplication_rate: 1.0,
+        };
+        op.apply(&mut buffer, &mut rng)
+            .expect("reduplication works");
+        assert_eq!(buffer.to_string(), "Hello Hello world world");
+    }
+
+    #[test]
+    fn delete_random_words_cleans_up_spacing() {
+        let mut buffer = TextBuffer::from_str("One two three four five");
+        let mut rng = PyRng::new(151);
+        let op = DeleteRandomWordsOp {
+            max_deletion_rate: 0.75,
+        };
+        op.apply(&mut buffer, &mut rng).expect("deletion works");
+        assert_eq!(buffer.to_string(), "One three four");
+    }
+
+    #[test]
+    fn redact_words_respects_sample_and_merge() {
+        let mut buffer = TextBuffer::from_str("Keep secrets safe");
+        let mut rng = PyRng::new(151);
+        let op = RedactWordsOp {
+            replacement_char: "█".to_string(),
+            redaction_rate: 0.8,
+            merge_adjacent: true,
+        };
+        op.apply(&mut buffer, &mut rng).expect("redaction works");
+        let result = buffer.to_string();
+        assert!(result.contains("█"));
+    }
+
+    #[test]
+    fn redact_words_without_candidates_errors() {
+        let mut buffer = TextBuffer::from_str("   ");
+        let mut rng = PyRng::new(151);
+        let op = RedactWordsOp {
+            replacement_char: "█".to_string(),
+            redaction_rate: 0.5,
+            merge_adjacent: false,
+        };
+        let error = op.apply(&mut buffer, &mut rng).unwrap_err();
+        match error {
+            GlitchOpError::NoRedactableWords => {}
+            other => panic!("expected no redactable words, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ocr_artifacts_replaces_expected_regions() {
+        let mut buffer = TextBuffer::from_str("Hello rn world");
+        let mut rng = PyRng::new(151);
+        let op = OcrArtifactsOp { error_rate: 1.0 };
+        op.apply(&mut buffer, &mut rng).expect("ocr works");
+        let text = buffer.to_string();
+        assert_ne!(text, "Hello rn world");
+        assert!(text.contains('m') || text.contains('h'));
+    }
+
+    #[test]
+    fn reduplication_matches_python_reference_seed_123() {
+        let mut buffer = TextBuffer::from_str("The quick brown fox");
+        let mut rng = PyRng::new(123);
+        let op = ReduplicateWordsOp {
+            reduplication_rate: 0.5,
+        };
+        op.apply(&mut buffer, &mut rng)
+            .expect("reduplication succeeds");
+        assert_eq!(
+            buffer.to_string(),
+            "The The quick quick brown brown fox fox"
+        );
+    }
+
+    #[test]
+    fn delete_matches_python_reference_seed_123() {
+        let mut buffer = TextBuffer::from_str("The quick brown fox jumps over the lazy dog.");
+        let mut rng = PyRng::new(123);
+        let op = DeleteRandomWordsOp {
+            max_deletion_rate: 0.5,
+        };
+        op.apply(&mut buffer, &mut rng).expect("deletion succeeds");
+        assert_eq!(buffer.to_string(), "The over the lazy dog.");
+    }
+
+    #[test]
+    fn redact_matches_python_reference_seed_42() {
+        let mut buffer = TextBuffer::from_str("Hide these words please");
+        let mut rng = PyRng::new(42);
+        let op = RedactWordsOp {
+            replacement_char: "█".to_string(),
+            redaction_rate: 0.5,
+            merge_adjacent: false,
+        };
+        op.apply(&mut buffer, &mut rng).expect("redaction succeeds");
+        assert_eq!(buffer.to_string(), "████ these words ██████");
+    }
+
+    #[test]
+    fn redact_merge_matches_python_reference_seed_7() {
+        let mut buffer = TextBuffer::from_str("redact these words");
+        let mut rng = PyRng::new(7);
+        let op = RedactWordsOp {
+            replacement_char: "█".to_string(),
+            redaction_rate: 1.0,
+            merge_adjacent: true,
+        };
+        op.apply(&mut buffer, &mut rng).expect("redaction succeeds");
+        assert_eq!(buffer.to_string(), "█████████████████");
+    }
+
+    #[test]
+    fn ocr_matches_python_reference_seed_1() {
+        let mut buffer = TextBuffer::from_str("The m rn");
+        let mut rng = PyRng::new(1);
+        let op = OcrArtifactsOp { error_rate: 1.0 };
+        op.apply(&mut buffer, &mut rng).expect("ocr succeeds");
+        assert_eq!(buffer.to_string(), "Tlie rn m");
+    }
+}

--- a/rust/zoo/src/glitch_ops.rs
+++ b/rust/zoo/src/glitch_ops.rs
@@ -299,7 +299,14 @@ impl GlitchOp for OcrArtifactsOp {
             return Ok(());
         }
 
-        let order = rng.sample_indices(candidates.len(), candidates.len())?;
+        let mut order: Vec<usize> = (0..candidates.len()).collect();
+        // We hand-roll Fisher–Yates instead of using helper utilities so the
+        // shuffle mirrors Python's `random.shuffle` exactly. The regression
+        // tests rely on this parity to keep the Rust and Python paths in lockstep.
+        for idx in (1..order.len()).rev() {
+            let swap_with = rng.rand_index(idx + 1)?;
+            order.swap(idx, swap_with);
+        }
         let mut chosen: Vec<(usize, usize, &'static str)> = Vec::new();
         let mut occupied: Vec<(usize, usize)> = Vec::new();
 

--- a/rust/zoo/src/lib.rs
+++ b/rust/zoo/src/lib.rs
@@ -63,6 +63,7 @@ impl<'py> GlitchRng for PythonRngAdapter<'py> {
 #[derive(Debug)]
 struct PyGlitchDescriptor {
     name: String,
+    seed: u64,
     operation: PyGlitchOperation,
 }
 
@@ -73,11 +74,15 @@ impl<'py> FromPyObject<'py> for PyGlitchDescriptor {
             .get_item("name")?
             .ok_or_else(|| PyValueError::new_err("descriptor missing 'name' field"))?
             .extract()?;
+        let seed = dict
+            .get_item("seed")?
+            .ok_or_else(|| PyValueError::new_err("descriptor missing 'seed' field"))?
+            .extract()?;
         let operation = dict
             .get_item("operation")?
             .ok_or_else(|| PyValueError::new_err("descriptor missing 'operation' field"))?
             .extract()?;
-        Ok(Self { name, operation })
+        Ok(Self { name, seed, operation })
     }
 }
 
@@ -257,6 +262,7 @@ fn compose_glitchlings(
             };
             Ok(GlitchDescriptor {
                 name: descriptor.name,
+                seed: descriptor.seed,
                 operation,
             })
         })

--- a/rust/zoo/src/pipeline.rs
+++ b/rust/zoo/src/pipeline.rs
@@ -1,0 +1,194 @@
+use blake2::digest::consts::U8;
+use blake2::{Blake2s, Digest};
+
+use crate::glitch_ops::{GlitchOp, GlitchOpError, GlitchOperation};
+use crate::rng::PyRng;
+use crate::text_buffer::TextBuffer;
+use pyo3::PyErr;
+
+/// Descriptor describing a glitchling to run as part of the pipeline.
+#[derive(Debug, Clone)]
+pub struct GlitchDescriptor {
+    pub name: String,
+    pub operation: GlitchOperation,
+}
+
+/// Errors emitted by the pipeline executor.
+#[derive(Debug)]
+pub enum PipelineError {
+    OperationFailure { name: String, source: GlitchOpError },
+}
+
+impl PipelineError {
+    pub fn into_pyerr(self) -> PyErr {
+        match self {
+            PipelineError::OperationFailure { source, .. } => source.into_pyerr(),
+        }
+    }
+}
+
+/// Deterministic glitchling pipeline mirroring the Python orchestrator contract.
+#[derive(Debug, Clone)]
+pub struct Pipeline {
+    master_seed: i128,
+    descriptors: Vec<GlitchDescriptor>,
+}
+
+impl Pipeline {
+    pub fn new(master_seed: i128, descriptors: Vec<GlitchDescriptor>) -> Self {
+        Self {
+            master_seed,
+            descriptors,
+        }
+    }
+
+    pub fn descriptors(&self) -> &[GlitchDescriptor] {
+        &self.descriptors
+    }
+
+    pub fn apply(&self, buffer: &mut TextBuffer) -> Result<(), PipelineError> {
+        for (index, descriptor) in self.descriptors.iter().enumerate() {
+            let seed = derive_seed(self.master_seed, &descriptor.name, index as i128);
+            let mut rng = PyRng::new(seed);
+            descriptor
+                .operation
+                .apply(buffer, &mut rng)
+                .map_err(|source| PipelineError::OperationFailure {
+                    name: descriptor.name.clone(),
+                    source,
+                })?;
+        }
+        Ok(())
+    }
+
+    pub fn run(&self, text: &str) -> Result<String, PipelineError> {
+        let mut buffer = TextBuffer::from_str(text);
+        self.apply(&mut buffer)?;
+        Ok(buffer.to_string())
+    }
+}
+
+pub fn derive_seed(master_seed: i128, glitchling_name: &str, index: i128) -> u64 {
+    let mut hasher = Blake2s::<U8>::new();
+    Digest::update(&mut hasher, int_to_bytes(master_seed));
+    Digest::update(&mut hasher, &[0]);
+    Digest::update(&mut hasher, glitchling_name.as_bytes());
+    Digest::update(&mut hasher, &[0]);
+    Digest::update(&mut hasher, int_to_bytes(index));
+    let digest = hasher.finalize();
+    u64::from_be_bytes(digest.into())
+}
+
+fn int_to_bytes(value: i128) -> Vec<u8> {
+    if value == 0 {
+        return vec![0];
+    }
+    if value > 0 {
+        let mut bytes = Vec::new();
+        let mut current = value;
+        while current > 0 {
+            bytes.push((current & 0xFF) as u8);
+            current >>= 8;
+        }
+        bytes.reverse();
+        return bytes;
+    }
+
+    let mut bytes = value.to_be_bytes().to_vec();
+    while bytes.len() > 1 {
+        let first = bytes[0];
+        let second = bytes[1];
+        if (first == 0xFF && (second & 0x80) != 0) || (first == 0x00 && (second & 0x80) == 0) {
+            bytes.remove(0);
+        } else {
+            break;
+        }
+    }
+    bytes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{derive_seed, GlitchDescriptor, Pipeline};
+    use crate::glitch_ops::{
+        DeleteRandomWordsOp, GlitchOperation, OcrArtifactsOp, RedactWordsOp, ReduplicateWordsOp,
+    };
+
+    #[test]
+    fn derive_seed_matches_python_reference() {
+        assert_eq!(derive_seed(151, "Reduple", 0), 14619582442299654959);
+        assert_eq!(derive_seed(151, "Rushmore", 1), 15756123308692553544);
+    }
+
+    #[test]
+    fn pipeline_applies_operations_in_order() {
+        let descriptors = vec![
+            GlitchDescriptor {
+                name: "Reduple".to_string(),
+                operation: GlitchOperation::Reduplicate(ReduplicateWordsOp {
+                    reduplication_rate: 1.0,
+                }),
+            },
+            GlitchDescriptor {
+                name: "Redactyl".to_string(),
+                operation: GlitchOperation::Redact(RedactWordsOp {
+                    replacement_char: "█".to_string(),
+                    redaction_rate: 0.5,
+                    merge_adjacent: false,
+                }),
+            },
+        ];
+        let pipeline = Pipeline::new(151, descriptors);
+        let output = pipeline.run("Guard the vault").expect("pipeline succeeds");
+        assert!(output.contains("Guard Guard"));
+    }
+
+    #[test]
+    fn pipeline_is_deterministic() {
+        let descriptors = vec![GlitchDescriptor {
+            name: "Reduple".to_string(),
+            operation: GlitchOperation::Reduplicate(ReduplicateWordsOp {
+                reduplication_rate: 0.5,
+            }),
+        }];
+        let pipeline = Pipeline::new(999, descriptors);
+        let a = pipeline.run("Stay focused").expect("run a");
+        let b = pipeline.run("Stay focused").expect("run b");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn pipeline_matches_python_reference_sequence() {
+        let descriptors = vec![
+            GlitchDescriptor {
+                name: "Reduple".to_string(),
+                operation: GlitchOperation::Reduplicate(ReduplicateWordsOp {
+                    reduplication_rate: 0.4,
+                }),
+            },
+            GlitchDescriptor {
+                name: "Rushmore".to_string(),
+                operation: GlitchOperation::Delete(DeleteRandomWordsOp {
+                    max_deletion_rate: 0.3,
+                }),
+            },
+            GlitchDescriptor {
+                name: "Redactyl".to_string(),
+                operation: GlitchOperation::Redact(RedactWordsOp {
+                    replacement_char: "█".to_string(),
+                    redaction_rate: 0.6,
+                    merge_adjacent: true,
+                }),
+            },
+            GlitchDescriptor {
+                name: "Scannequin".to_string(),
+                operation: GlitchOperation::Ocr(OcrArtifactsOp { error_rate: 0.25 }),
+            },
+        ];
+        let pipeline = Pipeline::new(404, descriptors);
+        let output = pipeline
+            .run("Guard the vault at midnight")
+            .expect("pipeline run succeeds");
+        assert_eq!(output, "████ the vault ███████");
+    }
+}

--- a/rust/zoo/src/resources.rs
+++ b/rust/zoo/src/resources.rs
@@ -40,10 +40,20 @@ static BASE_CONFUSION_TABLE: &[(&str, &[&str])] = &[
 /// Sorted confusion pairs reused by glitchling implementations.
 pub static OCR_CONFUSION_TABLE: Lazy<Vec<(&'static str, &'static [&'static str])>> =
     Lazy::new(|| {
-        let mut entries: Vec<(&'static str, &'static [&'static str])> =
-            BASE_CONFUSION_TABLE.iter().copied().collect();
-        entries.sort_by(|a, b| b.0.len().cmp(&a.0.len()).then_with(|| a.0.cmp(b.0)));
-        entries
+        let mut entries: Vec<(usize, (&'static str, &'static [&'static str]))> =
+            BASE_CONFUSION_TABLE
+                .iter()
+                .copied()
+                .enumerate()
+                .collect();
+        entries.sort_by(|a, b| {
+            let a_len = a.1 .0.len();
+            let b_len = b.1 .0.len();
+            b_len
+                .cmp(&a_len)
+                .then_with(|| a.0.cmp(&b.0))
+        });
+        entries.into_iter().map(|(_, pair)| pair).collect()
     });
 
 /// Returns the pre-sorted OCR confusion table.

--- a/rust/zoo/src/resources.rs
+++ b/rust/zoo/src/resources.rs
@@ -1,0 +1,162 @@
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+/// Precompiled regex removing spaces before punctuation characters.
+pub static SPACE_BEFORE_PUNCTUATION: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"\s+([.,;:])").expect("valid punctuation regex"));
+
+/// Precompiled regex collapsing stretches of whitespace into a single space.
+pub static MULTIPLE_WHITESPACE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"\s{2,}").expect("valid multi-whitespace regex"));
+
+static BASE_CONFUSION_TABLE: &[(&str, &[&str])] = &[
+    ("li", &["h"]),
+    ("h", &["li"]),
+    ("rn", &["m"]),
+    ("m", &["rn"]),
+    ("cl", &["d"]),
+    ("d", &["cl"]),
+    ("I", &["l"]),
+    ("l", &["I", "1"]),
+    ("1", &["l", "I"]),
+    ("0", &["O"]),
+    ("O", &["0"]),
+    ("B", &["8"]),
+    ("8", &["B"]),
+    ("S", &["5"]),
+    ("5", &["S"]),
+    ("Z", &["2"]),
+    ("2", &["Z"]),
+    ("G", &["6"]),
+    ("6", &["G"]),
+    ("“", &["\""]),
+    ("”", &["\""]),
+    ("‘", &["'"]),
+    ("’", &["'"]),
+    ("—", &["-"]),
+    ("–", &["-"]),
+];
+
+/// Sorted confusion pairs reused by glitchling implementations.
+pub static OCR_CONFUSION_TABLE: Lazy<Vec<(&'static str, &'static [&'static str])>> =
+    Lazy::new(|| {
+        let mut entries: Vec<(&'static str, &'static [&'static str])> =
+            BASE_CONFUSION_TABLE.iter().copied().collect();
+        entries.sort_by(|a, b| b.0.len().cmp(&a.0.len()).then_with(|| a.0.cmp(b.0)));
+        entries
+    });
+
+/// Returns the pre-sorted OCR confusion table.
+#[inline]
+pub fn confusion_table() -> &'static [(&'static str, &'static [&'static str])] {
+    OCR_CONFUSION_TABLE.as_slice()
+}
+
+#[inline]
+pub fn is_whitespace_only(s: &str) -> bool {
+    s.chars().all(char::is_whitespace)
+}
+
+#[inline]
+fn is_word_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_'
+}
+
+/// Splits text into alternating word and separator segments while retaining the separators.
+pub fn split_with_separators(text: &str) -> Vec<String> {
+    let mut tokens: Vec<String> = Vec::new();
+    let mut last = 0;
+    let mut iter = text.char_indices().peekable();
+
+    while let Some((idx, ch)) = iter.next() {
+        if ch.is_whitespace() {
+            let start = idx;
+            let mut end = idx + ch.len_utf8();
+            while let Some(&(next_idx, next_ch)) = iter.peek() {
+                if next_ch.is_whitespace() {
+                    iter.next();
+                    end = next_idx + next_ch.len_utf8();
+                } else {
+                    break;
+                }
+            }
+            tokens.push(text[last..start].to_string());
+            tokens.push(text[start..end].to_string());
+            last = end;
+        }
+    }
+
+    if last <= text.len() {
+        tokens.push(text[last..].to_string());
+    }
+
+    if tokens.is_empty() {
+        tokens.push(text.to_string());
+    }
+
+    tokens
+}
+
+/// Splits a word into leading punctuation, core token, and trailing punctuation.
+pub fn split_affixes(word: &str) -> (String, String, String) {
+    let mut start_index: Option<usize> = None;
+    let mut end_index = 0;
+
+    for (idx, ch) in word.char_indices() {
+        if is_word_char(ch) {
+            if start_index.is_none() {
+                start_index = Some(idx);
+            }
+            end_index = idx + ch.len_utf8();
+        }
+    }
+
+    match start_index {
+        Some(start) => (
+            word[..start].to_string(),
+            word[start..end_index].to_string(),
+            word[end_index..].to_string(),
+        ),
+        None => (word.to_string(), String::new(), String::new()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{confusion_table, split_affixes, split_with_separators};
+
+    #[test]
+    fn split_with_separators_matches_expected_boundaries() {
+        let parts = split_with_separators(" Hello  world\n");
+        assert_eq!(
+            parts,
+            vec![
+                "".to_string(),
+                " ".to_string(),
+                "Hello".to_string(),
+                "  ".to_string(),
+                "world".to_string(),
+                "\n".to_string(),
+                "".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn split_affixes_retains_punctuation() {
+        let (prefix, core, suffix) = split_affixes("(hello)!");
+        assert_eq!(prefix, "(");
+        assert_eq!(core, "hello");
+        assert_eq!(suffix, ")!");
+    }
+
+    #[test]
+    fn confusion_table_sorted_by_key_length() {
+        let table = confusion_table();
+        assert!(table.windows(2).all(|pair| {
+            let (a_src, _) = pair[0];
+            let (b_src, _) = pair[1];
+            a_src.len() >= b_src.len()
+        }));
+    }
+}

--- a/rust/zoo/src/rng.rs
+++ b/rust/zoo/src/rng.rs
@@ -1,0 +1,381 @@
+use std::collections::HashSet;
+use std::fmt;
+
+const STATE_SIZE: usize = 624;
+const M: usize = 397;
+const MATRIX_A: u32 = 0x9908B0DF;
+const UPPER_MASK: u32 = 0x8000_0000;
+const LOWER_MASK: u32 = 0x7FFF_FFFF;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum PyRngError {
+    EmptyRange(&'static str),
+    StepZero,
+    MissingStop,
+    UnsupportedBits(u32),
+    RangeTooLarge,
+}
+
+impl fmt::Display for PyRngError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyRange(context) => write!(f, "empty range in {context}"),
+            Self::StepZero => write!(f, "zero step for randrange()"),
+            Self::MissingStop => write!(f, "missing a non-None stop argument"),
+            Self::UnsupportedBits(bits) => write!(f, "unsupported bit request: {bits}"),
+            Self::RangeTooLarge => write!(f, "range is too large to sample"),
+        }
+    }
+}
+
+impl std::error::Error for PyRngError {}
+
+#[derive(Clone)]
+pub struct PyRng {
+    state: [u32; STATE_SIZE],
+    index: usize,
+}
+
+impl PyRng {
+    pub fn new(seed: u64) -> Self {
+        let mut rng = Self {
+            state: [0; STATE_SIZE],
+            index: STATE_SIZE,
+        };
+        rng.seed(seed);
+        rng
+    }
+
+    pub fn seed(&mut self, seed: u64) {
+        let mut key = if seed == 0 {
+            Vec::from([0u32])
+        } else {
+            Vec::new()
+        };
+        if seed != 0 {
+            let mut value = seed;
+            while value > 0 {
+                key.push((value & 0xFFFF_FFFF) as u32);
+                value >>= 32;
+            }
+        }
+        self.init_by_array(&key);
+    }
+
+    fn init_by_array(&mut self, key: &[u32]) {
+        self.state[0] = 19650218;
+        for i in 1..STATE_SIZE {
+            let prev = self.state[i - 1];
+            self.state[i] = 1812433253u32
+                .wrapping_mul(prev ^ (prev >> 30))
+                .wrapping_add(i as u32);
+        }
+        let mut i = 1usize;
+        let mut j = 0usize;
+        let key_len = key.len().max(1);
+        let mut k = STATE_SIZE.max(key_len);
+        while k > 0 {
+            let prev = self.state[(i + STATE_SIZE - 1) % STATE_SIZE];
+            self.state[i] = (self.state[i] ^ ((prev ^ (prev >> 30)).wrapping_mul(1664525)))
+                .wrapping_add(*key.get(j).unwrap_or(&0))
+                .wrapping_add(j as u32);
+            i += 1;
+            j += 1;
+            if i >= STATE_SIZE {
+                self.state[0] = self.state[STATE_SIZE - 1];
+                i = 1;
+            }
+            if j >= key_len {
+                j = 0;
+            }
+            k -= 1;
+        }
+        k = STATE_SIZE - 1;
+        while k > 0 {
+            let prev = self.state[(i + STATE_SIZE - 1) % STATE_SIZE];
+            self.state[i] = (self.state[i] ^ ((prev ^ (prev >> 30)).wrapping_mul(1566083941)))
+                .wrapping_sub(i as u32);
+            i += 1;
+            if i >= STATE_SIZE {
+                self.state[0] = self.state[STATE_SIZE - 1];
+                i = 1;
+            }
+            k -= 1;
+        }
+        self.state[0] = 0x8000_0000;
+        self.index = STATE_SIZE;
+    }
+
+    fn twist(&mut self) {
+        for i in 0..STATE_SIZE {
+            let x = (self.state[i] & UPPER_MASK) + (self.state[(i + 1) % STATE_SIZE] & LOWER_MASK);
+            let mut xa = x >> 1;
+            if x & 1 != 0 {
+                xa ^= MATRIX_A;
+            }
+            self.state[i] = self.state[(i + M) % STATE_SIZE] ^ xa;
+        }
+        self.index = 0;
+    }
+
+    fn gen_u32(&mut self) -> u32 {
+        if self.index >= STATE_SIZE {
+            self.twist();
+        }
+        let mut y = self.state[self.index];
+        self.index += 1;
+        y ^= y >> 11;
+        y ^= (y << 7) & 0x9D2C5680;
+        y ^= (y << 15) & 0xEFC60000;
+        y ^= y >> 18;
+        y
+    }
+
+    pub fn random(&mut self) -> f64 {
+        let a = (self.gen_u32() >> 5) as u64;
+        let b = (self.gen_u32() >> 6) as u64;
+        ((a << 26) + b) as f64 * (1.0 / (1u64 << 53) as f64)
+    }
+
+    pub fn getrandbits(&mut self, k: u32) -> Result<u128, PyRngError> {
+        if k == 0 {
+            return Ok(0);
+        }
+        if k > 128 {
+            return Err(PyRngError::UnsupportedBits(k));
+        }
+        if k <= 32 {
+            return Ok((self.gen_u32() >> (32 - k)) as u128);
+        }
+        let mut bits_remaining = k;
+        let mut words: Vec<u32> = Vec::with_capacity(((k - 1) / 32 + 1) as usize);
+        while bits_remaining > 0 {
+            let mut r = self.gen_u32();
+            if bits_remaining < 32 {
+                r >>= 32 - bits_remaining;
+            }
+            words.push(r);
+            bits_remaining = bits_remaining.saturating_sub(32);
+        }
+        let mut value: u128 = 0;
+        for (i, word) in words.iter().enumerate() {
+            value |= (*word as u128) << (32 * i as u32);
+        }
+        Ok(value)
+    }
+
+    pub fn randbelow(&mut self, n: u64) -> Result<u64, PyRngError> {
+        if n == 0 {
+            return Err(PyRngError::EmptyRange("randrange()"));
+        }
+        let k = 64 - n.leading_zeros();
+        loop {
+            let r = self.getrandbits(k)?;
+            if r < n as u128 {
+                return Ok(r as u64);
+            }
+        }
+    }
+
+    pub fn randrange(
+        &mut self,
+        start: i64,
+        stop: Option<i64>,
+        step: i64,
+    ) -> Result<i64, PyRngError> {
+        match stop {
+            None => {
+                if step != 1 {
+                    return Err(PyRngError::MissingStop);
+                }
+                if start > 0 {
+                    return Ok(self.randbelow(start as u64)? as i64);
+                }
+                Err(PyRngError::EmptyRange("randrange()"))
+            }
+            Some(stop_value) => {
+                let width = stop_value as i128 - start as i128;
+                let step128 = step as i128;
+                if step128 == 1 {
+                    if width > 0 {
+                        if width as u128 > u64::MAX as u128 {
+                            return Err(PyRngError::RangeTooLarge);
+                        }
+                        return Ok(start + self.randbelow(width as u64)? as i64);
+                    }
+                    return Err(PyRngError::EmptyRange("randrange(start, stop)"));
+                }
+                if step128 == 0 {
+                    return Err(PyRngError::StepZero);
+                }
+                let numerator = if step128 > 0 {
+                    width + step128 - 1
+                } else {
+                    width + step128 + 1
+                };
+                let n = div_floor(numerator, step128);
+                if n <= 0 {
+                    return Err(PyRngError::EmptyRange("randrange(start, stop, step)"));
+                }
+                if n as u128 > u64::MAX as u128 {
+                    return Err(PyRngError::RangeTooLarge);
+                }
+                let offset = self.randbelow(n as u64)? as i128;
+                Ok((start as i128 + step128 * offset) as i64)
+            }
+        }
+    }
+
+    pub fn sample_indices(
+        &mut self,
+        population: usize,
+        k: usize,
+    ) -> Result<Vec<usize>, PyRngError> {
+        if k > population {
+            return Err(PyRngError::EmptyRange("sample()"));
+        }
+        let mut result = Vec::with_capacity(k);
+        if k == 0 {
+            return Ok(result);
+        }
+        let mut setsize: usize = 21;
+        if k > 5 {
+            let exponent = ((k * 3) as f64).log(4.0).ceil() as u32;
+            setsize += 4usize.pow(exponent);
+        }
+        if population <= setsize {
+            let mut pool: Vec<usize> = (0..population).collect();
+            for i in 0..k {
+                let j = self.randbelow((population - i) as u64)? as usize;
+                result.push(pool[j]);
+                pool.swap(j, population - i - 1);
+            }
+        } else {
+            let mut selected: HashSet<usize> = HashSet::with_capacity(k);
+            while result.len() < k {
+                let j = self.randbelow(population as u64)? as usize;
+                if selected.insert(j) {
+                    result.push(j);
+                }
+            }
+        }
+        Ok(result)
+    }
+
+    pub fn sample<T: Clone>(&mut self, population: &[T], k: usize) -> Result<Vec<T>, PyRngError> {
+        let indices = self.sample_indices(population.len(), k)?;
+        let mut out = Vec::with_capacity(k);
+        for index in indices {
+            out.push(population[index].clone());
+        }
+        Ok(out)
+    }
+}
+
+fn div_floor(a: i128, b: i128) -> i128 {
+    let mut q = a / b;
+    let r = a % b;
+    if (r > 0 && b < 0) || (r < 0 && b > 0) {
+        q -= 1;
+    }
+    q
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PyRng;
+
+    #[test]
+    fn random_matches_python_for_master_seed() {
+        let mut rng = PyRng::new(151);
+        let expected = [
+            0.7065737352491744,
+            0.8459813212725689,
+            0.9507856720093933,
+            0.6327886858871649,
+            0.20461024606293488,
+        ];
+        for value in expected {
+            let actual = rng.random();
+            assert!(
+                (actual - value).abs() < 1e-15,
+                "expected {value}, got {actual}"
+            );
+        }
+    }
+
+    #[test]
+    fn random_matches_python_for_derived_seed() {
+        let mut rng = PyRng::new(13006513535068165406);
+        let expected = [
+            0.035611281084551805,
+            0.303230319068173,
+            0.5505529172330853,
+            0.03282053534387952,
+            0.013761028062003189,
+        ];
+        for value in expected {
+            let actual = rng.random();
+            assert!(
+                (actual - value).abs() < 1e-15,
+                "expected {value}, got {actual}"
+            );
+        }
+    }
+
+    #[test]
+    fn randrange_supports_default_arguments() {
+        let mut rng = PyRng::new(151);
+        let expected = [6, 3, 5, 4, 5];
+        for value in expected {
+            let actual = rng.randrange(10, None, 1).unwrap();
+            assert_eq!(value, actual);
+        }
+    }
+
+    #[test]
+    fn randrange_supports_custom_step() {
+        let mut rng = PyRng::new(151);
+        let expected = [35, 20, 30, 25, 30];
+        for value in expected {
+            let actual = rng.randrange(5, Some(50), 5).unwrap();
+            assert_eq!(value, actual);
+        }
+        let mut rng = PyRng::new(13006513535068165406);
+        let expected = [-50, -35, -30, -15, -10];
+        for value in expected {
+            let actual = rng.randrange(-50, Some(-5), 5).unwrap();
+            assert_eq!(value, actual);
+        }
+    }
+
+    #[test]
+    fn getrandbits_matches_python() {
+        let mut rng = PyRng::new(151);
+        assert_eq!(2894, rng.getrandbits(12).unwrap());
+        assert_eq!(1950700110956246240, rng.getrandbits(61).unwrap());
+        let mut rng = PyRng::new(13006513535068165406);
+        assert_eq!(145, rng.getrandbits(12).unwrap());
+        assert_eq!(699201512668378865, rng.getrandbits(61).unwrap());
+    }
+
+    #[test]
+    fn sample_matches_python_small_population() {
+        let mut rng = PyRng::new(151);
+        let population: Vec<_> = (0..20).collect();
+        let actual = rng.sample(&population, 5).unwrap();
+        let expected = vec![13, 6, 11, 9, 17];
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn sample_matches_python_large_population() {
+        let mut rng = PyRng::new(13006513535068165406);
+        let population: Vec<_> = (0..1000).collect();
+        let actual = rng.sample(&population, 15).unwrap();
+        let expected = vec![
+            36, 244, 310, 497, 563, 711, 33, 702, 14, 943, 239, 435, 252, 40, 623,
+        ];
+        assert_eq!(expected, actual);
+    }
+}

--- a/rust/zoo/src/text_buffer.rs
+++ b/rust/zoo/src/text_buffer.rs
@@ -1,0 +1,427 @@
+use std::ops::Range;
+
+use crate::resources::split_with_separators;
+
+/// Represents the role of a segment inside a [`TextBuffer`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SegmentKind {
+    /// A token that contains at least one non-whitespace character.
+    Word,
+    /// A run of whitespace characters separating words.
+    Separator,
+}
+
+/// A contiguous slice of text tracked by the [`TextBuffer`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TextSegment {
+    kind: SegmentKind,
+    text: String,
+}
+
+impl TextSegment {
+    fn new(text: String, kind: SegmentKind) -> Self {
+        Self { kind, text }
+    }
+
+    /// Creates a new segment and infers its kind from the content.
+    fn inferred(text: String) -> Self {
+        let kind = if text.chars().all(char::is_whitespace) {
+            SegmentKind::Separator
+        } else {
+            SegmentKind::Word
+        };
+        Self::new(text, kind)
+    }
+
+    /// Returns the segment's text content.
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+
+    /// Returns the classification of the segment.
+    pub fn kind(&self) -> SegmentKind {
+        self.kind
+    }
+
+    fn set_text(&mut self, text: String, kind: SegmentKind) {
+        self.text = text;
+        self.kind = kind;
+    }
+}
+
+/// Metadata describing where a [`TextSegment`] lives inside the overall buffer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TextSpan {
+    pub segment_index: usize,
+    pub kind: SegmentKind,
+    pub char_range: Range<usize>,
+    pub byte_range: Range<usize>,
+}
+
+/// Errors emitted by [`TextBuffer`] mutation helpers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TextBufferError {
+    InvalidWordIndex {
+        index: usize,
+    },
+    InvalidCharRange {
+        start: usize,
+        end: usize,
+        max: usize,
+    },
+}
+
+impl std::fmt::Display for TextBufferError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TextBufferError::InvalidWordIndex { index } => {
+                write!(f, "invalid word index {index}")
+            }
+            TextBufferError::InvalidCharRange { start, end, max } => {
+                write!(
+                    f,
+                    "invalid character range {start}..{end}; buffer length is {max} characters",
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for TextBufferError {}
+
+/// Shared intermediate representation for the Rust pipeline refactor.
+///
+/// The buffer tokenises the input text once, maintains lightweight metadata for
+/// each segment, and offers mutation helpers that keep the metadata in sync so
+/// glitchlings can operate deterministically without re-tokenising after each
+/// operation.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TextBuffer {
+    segments: Vec<TextSegment>,
+    spans: Vec<TextSpan>,
+    word_segment_indices: Vec<usize>,
+    total_chars: usize,
+    total_bytes: usize,
+}
+
+impl TextBuffer {
+    /// Constructs a buffer from an owned `String`.
+    pub fn from_owned(text: String) -> Self {
+        let mut buffer = Self {
+            segments: tokenise(&text),
+            spans: Vec::new(),
+            word_segment_indices: Vec::new(),
+            total_chars: 0,
+            total_bytes: 0,
+        };
+        buffer.reindex();
+        buffer
+    }
+
+    /// Constructs a buffer from a borrowed `&str`.
+    pub fn from_str(text: &str) -> Self {
+        Self::from_owned(text.to_string())
+    }
+
+    /// Returns all tracked segments.
+    pub fn segments(&self) -> &[TextSegment] {
+        &self.segments
+    }
+
+    /// Returns metadata spans describing segment positions.
+    pub fn spans(&self) -> &[TextSpan] {
+        &self.spans
+    }
+
+    /// Returns the number of characters across the entire buffer.
+    pub fn char_len(&self) -> usize {
+        self.total_chars
+    }
+
+    /// Returns the number of word segments tracked by the buffer.
+    pub fn word_count(&self) -> usize {
+        self.word_segment_indices.len()
+    }
+
+    /// Returns the `TextSegment` corresponding to the requested word index.
+    pub fn word_segment(&self, word_index: usize) -> Option<&TextSegment> {
+        self.word_segment_indices
+            .get(word_index)
+            .copied()
+            .and_then(|segment_index| self.segments.get(segment_index))
+    }
+
+    /// Replace the text for the given word index.
+    pub fn replace_word(
+        &mut self,
+        word_index: usize,
+        replacement: &str,
+    ) -> Result<(), TextBufferError> {
+        let segment_index = self
+            .word_segment_indices
+            .get(word_index)
+            .copied()
+            .ok_or(TextBufferError::InvalidWordIndex { index: word_index })?;
+        let segment = self
+            .segments
+            .get_mut(segment_index)
+            .ok_or(TextBufferError::InvalidWordIndex { index: word_index })?;
+        segment.set_text(replacement.to_string(), SegmentKind::Word);
+        self.reindex();
+        Ok(())
+    }
+
+    /// Deletes the word at the requested index.
+    pub fn delete_word(&mut self, word_index: usize) -> Result<(), TextBufferError> {
+        let segment_index = self
+            .word_segment_indices
+            .get(word_index)
+            .copied()
+            .ok_or(TextBufferError::InvalidWordIndex { index: word_index })?;
+        if segment_index >= self.segments.len() {
+            return Err(TextBufferError::InvalidWordIndex { index: word_index });
+        }
+        self.segments.remove(segment_index);
+        self.reindex();
+        Ok(())
+    }
+
+    /// Inserts a word directly after the provided word index.
+    ///
+    /// When `separator` is provided it will be inserted between the existing
+    /// word and the new word as a separator segment, allowing callers to
+    /// preserve whitespace decisions.
+    pub fn insert_word_after(
+        &mut self,
+        word_index: usize,
+        word: &str,
+        separator: Option<&str>,
+    ) -> Result<(), TextBufferError> {
+        let segment_index = self
+            .word_segment_indices
+            .get(word_index)
+            .copied()
+            .ok_or(TextBufferError::InvalidWordIndex { index: word_index })?;
+        let mut insert_at = segment_index + 1;
+        if let Some(sep) = separator {
+            if !sep.is_empty() {
+                self.segments.insert(
+                    insert_at,
+                    TextSegment::new(sep.to_string(), SegmentKind::Separator),
+                );
+                insert_at += 1;
+            }
+        }
+        self.segments.insert(
+            insert_at,
+            TextSegment::new(word.to_string(), SegmentKind::Word),
+        );
+        self.reindex();
+        Ok(())
+    }
+
+    /// Replaces the provided character range with new text.
+    pub fn replace_char_range(
+        &mut self,
+        char_range: Range<usize>,
+        replacement: &str,
+    ) -> Result<(), TextBufferError> {
+        if char_range.start > char_range.end || char_range.end > self.total_chars {
+            return Err(TextBufferError::InvalidCharRange {
+                start: char_range.start,
+                end: char_range.end,
+                max: self.total_chars,
+            });
+        }
+
+        if char_range.start == char_range.end && replacement.is_empty() {
+            return Ok(());
+        }
+
+        let mut text = self.to_string();
+        let start_byte =
+            self.char_to_byte_index(char_range.start)
+                .ok_or(TextBufferError::InvalidCharRange {
+                    start: char_range.start,
+                    end: char_range.end,
+                    max: self.total_chars,
+                })?;
+        let end_byte =
+            self.char_to_byte_index(char_range.end)
+                .ok_or(TextBufferError::InvalidCharRange {
+                    start: char_range.start,
+                    end: char_range.end,
+                    max: self.total_chars,
+                })?;
+        text.replace_range(start_byte..end_byte, replacement);
+        *self = TextBuffer::from_owned(text);
+        Ok(())
+    }
+
+    /// Returns the full text represented by the buffer.
+    pub fn to_string(&self) -> String {
+        self.segments
+            .iter()
+            .map(|segment| segment.text.as_str())
+            .collect()
+    }
+
+    fn char_to_byte_index(&self, char_index: usize) -> Option<usize> {
+        if char_index > self.total_chars {
+            return None;
+        }
+        if char_index == self.total_chars {
+            return Some(self.total_bytes);
+        }
+        for span in &self.spans {
+            if span.char_range.contains(&char_index) {
+                let relative = char_index - span.char_range.start;
+                let segment = &self.segments[span.segment_index];
+                let byte_offset = byte_index_for_char_offset(segment.text(), relative);
+                return Some(span.byte_range.start + byte_offset);
+            }
+        }
+        None
+    }
+
+    fn reindex(&mut self) {
+        self.spans.clear();
+        self.word_segment_indices.clear();
+        let mut char_cursor = 0;
+        let mut byte_cursor = 0;
+        for (segment_index, segment) in self.segments.iter().enumerate() {
+            let char_len = segment.text().chars().count();
+            let byte_len = segment.text().len();
+            let span = TextSpan {
+                segment_index,
+                kind: segment.kind(),
+                char_range: char_cursor..(char_cursor + char_len),
+                byte_range: byte_cursor..(byte_cursor + byte_len),
+            };
+            if matches!(segment.kind(), SegmentKind::Word) {
+                self.word_segment_indices.push(segment_index);
+            }
+            self.spans.push(span);
+            char_cursor += char_len;
+            byte_cursor += byte_len;
+        }
+        self.total_chars = char_cursor;
+        self.total_bytes = byte_cursor;
+    }
+}
+
+fn byte_index_for_char_offset(text: &str, offset: usize) -> usize {
+    if offset == 0 {
+        return 0;
+    }
+    let mut count = 0;
+    for (byte_index, _) in text.char_indices() {
+        if count == offset {
+            return byte_index;
+        }
+        count += 1;
+    }
+    text.len()
+}
+
+fn tokenise(text: &str) -> Vec<TextSegment> {
+    if text.is_empty() {
+        return Vec::new();
+    }
+
+    let mut segments: Vec<TextSegment> = Vec::new();
+    for token in split_with_separators(text) {
+        if token.is_empty() {
+            continue;
+        }
+
+        if token.chars().all(char::is_whitespace) {
+            segments.push(TextSegment::new(token, SegmentKind::Separator));
+        } else {
+            segments.push(TextSegment::new(token, SegmentKind::Word));
+        }
+    }
+
+    if segments.is_empty() {
+        segments.push(TextSegment::inferred(text.to_string()));
+    }
+
+    segments
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SegmentKind, TextBuffer, TextBufferError};
+
+    #[test]
+    fn tokenisation_tracks_words_and_separators() {
+        let buffer = TextBuffer::from_str("Hello  world!\n");
+        let segments = buffer.segments();
+        assert_eq!(segments.len(), 4);
+        assert_eq!(segments[0].text(), "Hello");
+        assert_eq!(segments[0].kind(), SegmentKind::Word);
+        assert_eq!(segments[1].text(), "  ");
+        assert_eq!(segments[1].kind(), SegmentKind::Separator);
+        assert_eq!(segments[2].text(), "world!");
+        assert_eq!(segments[2].kind(), SegmentKind::Word);
+        assert_eq!(segments[3].text(), "\n");
+        assert_eq!(segments[3].kind(), SegmentKind::Separator);
+
+        assert_eq!(buffer.char_len(), "Hello  world!\n".chars().count());
+        assert_eq!(buffer.word_count(), 2);
+    }
+
+    #[test]
+    fn replacing_words_updates_segments_and_metadata() {
+        let mut buffer = TextBuffer::from_str("Hello world");
+        buffer.replace_word(1, "galaxy").unwrap();
+        assert_eq!(buffer.to_string(), "Hello galaxy");
+        let spans = buffer.spans();
+        assert_eq!(spans.len(), 3);
+        assert_eq!(spans[2].char_range, 6..12);
+    }
+
+    #[test]
+    fn deleting_words_removes_segments() {
+        let mut buffer = TextBuffer::from_str("Hello brave world");
+        buffer.delete_word(1).unwrap();
+        assert_eq!(buffer.to_string(), "Hello  world");
+        assert_eq!(buffer.word_count(), 2);
+        assert_eq!(buffer.spans().len(), 4);
+        assert!(buffer.spans()[1..3]
+            .iter()
+            .all(|span| matches!(span.kind, SegmentKind::Separator)));
+    }
+
+    #[test]
+    fn inserting_words_preserves_separator_control() {
+        let mut buffer = TextBuffer::from_str("Hello world");
+        buffer.insert_word_after(0, "there", Some(", ")).unwrap();
+        assert_eq!(buffer.to_string(), "Hello, there world");
+        assert_eq!(buffer.word_count(), 3);
+        assert_eq!(buffer.spans().len(), 5);
+    }
+
+    #[test]
+    fn replace_char_range_handles_multisegment_updates() {
+        let mut buffer = TextBuffer::from_str("Hello world");
+        buffer
+            .replace_char_range(6..11, "galaxy")
+            .expect("char replacement succeeded");
+        assert_eq!(buffer.to_string(), "Hello galaxy");
+        assert_eq!(buffer.word_count(), 2);
+        assert_eq!(buffer.spans().len(), 3);
+    }
+
+    #[test]
+    fn invalid_operations_return_errors() {
+        let mut buffer = TextBuffer::from_str("Hello");
+        let err = buffer.replace_word(1, "world").unwrap_err();
+        assert!(matches!(err, TextBufferError::InvalidWordIndex { .. }));
+
+        let err = buffer
+            .replace_char_range(2..10, "x")
+            .expect_err("range outside bounds");
+        assert!(matches!(err, TextBufferError::InvalidCharRange { .. }));
+    }
+}

--- a/src/glitchlings/zoo/core.py
+++ b/src/glitchlings/zoo/core.py
@@ -297,6 +297,7 @@ class Gaggle(Glitchling):
             _g = g.clone()
             derived_seed = Gaggle.derive_seed(seed, _g.name, idx)
             _g.reset_rng(derived_seed)
+            setattr(_g, "_gaggle_index", idx)
             self.glitchlings[g.level].append(_g)
         self.sort_glitchlings()
 
@@ -360,7 +361,22 @@ class Gaggle(Glitchling):
             operation = builder(glitchling)
             if operation is None:
                 return None
-            descriptors.append({"name": glitchling.name, "operation": operation})
+
+            seed = glitchling.seed
+            if seed is None:
+                index = getattr(glitchling, "_gaggle_index", None)
+                master_seed = self.seed
+                if index is None or master_seed is None:
+                    return None
+                seed = Gaggle.derive_seed(master_seed, glitchling.name, index)
+
+            descriptors.append(
+                {
+                    "name": glitchling.name,
+                    "operation": operation,
+                    "seed": int(seed),
+                }
+            )
 
         return descriptors
 

--- a/tests/test_rust_backed_glitchlings.py
+++ b/tests/test_rust_backed_glitchlings.py
@@ -7,6 +7,7 @@ reduple_module = importlib.import_module("glitchlings.zoo.reduple")
 rushmore_module = importlib.import_module("glitchlings.zoo.rushmore")
 scannequin_module = importlib.import_module("glitchlings.zoo.scannequin")
 redactyl_module = importlib.import_module("glitchlings.zoo.redactyl")
+core_module = importlib.import_module("glitchlings.zoo.core")
 
 
 def test_reduple_matches_python_fallback():
@@ -108,3 +109,187 @@ def test_redactyl_whitespace_only_text_raises_value_error():
     message = "contains no redactable words"
     with pytest.raises(ValueError, match=message):
         redactyl_module.redact_words("   \t\n  ", seed=2)
+
+
+def _run_python_sequence(text: str, descriptors: list[dict[str, object]], master_seed: int) -> str:
+    current = text
+    for index, descriptor in enumerate(descriptors):
+        rng_seed = core_module.Gaggle.derive_seed(master_seed, descriptor["name"], index)
+        rng = random.Random(rng_seed)
+        operation = descriptor["operation"]
+        op_type = operation["type"]
+        if op_type == "reduplicate":
+            current = reduple_module._python_reduplicate_words(
+                current,
+                reduplication_rate=operation["reduplication_rate"],
+                rng=rng,
+            )
+        elif op_type == "delete":
+            current = rushmore_module._python_delete_random_words(
+                current,
+                max_deletion_rate=operation["max_deletion_rate"],
+                rng=rng,
+            )
+        elif op_type == "redact":
+            current = redactyl_module._python_redact_words(
+                current,
+                replacement_char=operation["replacement_char"],
+                redaction_rate=operation["redaction_rate"],
+                merge_adjacent=operation["merge_adjacent"],
+                rng=rng,
+            )
+        elif op_type == "ocr":
+            current = scannequin_module._python_ocr_artifacts(
+                current,
+                error_rate=operation["error_rate"],
+                rng=rng,
+            )
+        else:  # pragma: no cover - defensive guard
+            raise AssertionError(f"Unsupported operation type: {op_type!r}")
+    return current
+
+
+def test_compose_glitchlings_matches_python_pipeline():
+    zoo_rust = pytest.importorskip("glitchlings._zoo_rust")
+    descriptors = [
+        {"name": "Reduple", "operation": {"type": "reduplicate", "reduplication_rate": 0.4}},
+        {"name": "Rushmore", "operation": {"type": "delete", "max_deletion_rate": 0.5}},
+        {
+            "name": "Redactyl",
+            "operation": {
+                "type": "redact",
+                "replacement_char": redactyl_module.FULL_BLOCK,
+                "redaction_rate": 0.6,
+                "merge_adjacent": True,
+            },
+        },
+        {"name": "Scannequin", "operation": {"type": "ocr", "error_rate": 0.25}},
+    ]
+    text = "Guard the vault at midnight"
+    master_seed = 404
+    expected = _run_python_sequence(text, descriptors, master_seed)
+    result = zoo_rust.compose_glitchlings(text, descriptors, master_seed)
+    assert result == expected
+
+
+def test_compose_glitchlings_is_deterministic():
+    zoo_rust = pytest.importorskip("glitchlings._zoo_rust")
+    descriptors = [
+        {"name": "Reduple", "operation": {"type": "reduplicate", "reduplication_rate": 0.4}},
+        {"name": "Rushmore", "operation": {"type": "delete", "max_deletion_rate": 0.3}},
+        {
+            "name": "Redactyl",
+            "operation": {
+                "type": "redact",
+                "replacement_char": redactyl_module.FULL_BLOCK,
+                "redaction_rate": 0.6,
+                "merge_adjacent": True,
+            },
+        },
+    ]
+    text = "Guard the vault at midnight"
+    first = zoo_rust.compose_glitchlings(text, descriptors, 777)
+    second = zoo_rust.compose_glitchlings(text, descriptors, 777)
+    assert first == second == _run_python_sequence(text, descriptors, 777)
+
+
+def test_compose_glitchlings_propagates_glitch_errors():
+    zoo_rust = pytest.importorskip("glitchlings._zoo_rust")
+    descriptors = [
+        {
+            "name": "Redactyl",
+            "operation": {
+                "type": "redact",
+                "replacement_char": redactyl_module.FULL_BLOCK,
+                "redaction_rate": 1.0,
+                "merge_adjacent": False,
+            },
+        }
+    ]
+    with pytest.raises(ValueError, match="contains no redactable words"):
+        zoo_rust.compose_glitchlings("   \t", descriptors, 404)
+
+
+def test_gaggle_prefers_rust_pipeline(monkeypatch):
+    zoo_rust = pytest.importorskip("glitchlings._zoo_rust")
+    original_compose = zoo_rust.compose_glitchlings
+    calls: list[tuple[str, list[dict[str, object]], int]] = []
+
+    def spy(text: str, descriptors: list[dict[str, object]], master_seed: int) -> str:
+        calls.append((text, descriptors, master_seed))
+        return original_compose(text, descriptors, master_seed)
+
+    monkeypatch.setenv("GLITCHLINGS_RUST_PIPELINE", "1")
+    monkeypatch.setattr(zoo_rust, "compose_glitchlings", spy)
+    monkeypatch.setattr(core_module, "_compose_glitchlings_rust", spy, raising=False)
+
+    def _fail(*_args: object, **_kwargs: object) -> str:
+        raise AssertionError("Python fallback invoked")
+
+    monkeypatch.setattr(reduple_module, "reduplicate_words", _fail)
+    monkeypatch.setattr(rushmore_module, "delete_random_words", _fail)
+    monkeypatch.setattr(redactyl_module, "redact_words", _fail)
+    monkeypatch.setattr(scannequin_module, "ocr_artifacts", _fail)
+
+    gaggle = core_module.Gaggle(
+        [
+            reduple_module.Reduple(reduplication_rate=0.4),
+            rushmore_module.Rushmore(max_deletion_rate=0.3),
+            redactyl_module.Redactyl(redaction_rate=0.5, merge_adjacent=True),
+            scannequin_module.Scannequin(error_rate=0.2),
+        ],
+        seed=777,
+    )
+
+    text = "Safeguard the archive tonight"
+    result = gaggle(text)
+    assert calls, "Expected the Rust pipeline to be invoked"
+    descriptors = calls[0][1]
+    expected = _run_python_sequence(text, descriptors, 777)
+    assert result == expected
+
+
+def test_gaggle_python_fallback_when_pipeline_disabled(monkeypatch):
+    pytest.importorskip("glitchlings._zoo_rust")
+
+    def _fail(*_args: object, **_kwargs: object) -> str:
+        raise AssertionError("Rust pipeline should not run when feature flag is disabled")
+
+    monkeypatch.delenv("GLITCHLINGS_RUST_PIPELINE", raising=False)
+    monkeypatch.setattr(core_module, "_compose_glitchlings_rust", _fail, raising=False)
+
+    gaggle = core_module.Gaggle(
+        [
+            reduple_module.Reduple(reduplication_rate=0.4),
+            rushmore_module.Rushmore(max_deletion_rate=0.3),
+        ],
+        seed=2024,
+    )
+
+    text = "Hold the door"
+    result = gaggle(text)
+    descriptors = [
+        {"name": "Reduple", "operation": {"type": "reduplicate", "reduplication_rate": 0.4}},
+        {"name": "Rushmore", "operation": {"type": "delete", "max_deletion_rate": 0.3}},
+    ]
+    expected = _run_python_sequence(text, descriptors, 2024)
+    assert result == expected
+
+
+def test_rust_pipeline_feature_flag_introspection(monkeypatch):
+    monkeypatch.delenv("GLITCHLINGS_RUST_PIPELINE", raising=False)
+    assert not core_module._pipeline_feature_flag_enabled()
+    assert core_module.Gaggle.rust_pipeline_supported() is (
+        core_module._compose_glitchlings_rust is not None
+    )
+    assert not core_module.Gaggle.rust_pipeline_enabled()
+
+    monkeypatch.setenv("GLITCHLINGS_RUST_PIPELINE", "1")
+    if core_module.Gaggle.rust_pipeline_supported():
+        assert core_module.Gaggle.rust_pipeline_enabled()
+    else:
+        assert not core_module.Gaggle.rust_pipeline_enabled()
+
+    monkeypatch.setenv("GLITCHLINGS_RUST_PIPELINE", "false")
+    assert not core_module._pipeline_feature_flag_enabled()
+    assert not core_module.Gaggle.rust_pipeline_enabled()

--- a/tests/test_rust_backed_glitchlings.py
+++ b/tests/test_rust_backed_glitchlings.py
@@ -10,6 +10,23 @@ redactyl_module = importlib.import_module("glitchlings.zoo.redactyl")
 core_module = importlib.import_module("glitchlings.zoo.core")
 
 
+def _with_descriptor_seeds(
+    descriptors: list[dict[str, object]], master_seed: int
+) -> list[dict[str, object]]:
+    seeded: list[dict[str, object]] = []
+    for index, descriptor in enumerate(descriptors):
+        seeded.append(
+            {
+                "name": descriptor["name"],
+                "operation": dict(descriptor["operation"]),
+                "seed": core_module.Gaggle.derive_seed(
+                    master_seed, descriptor["name"], index
+                ),
+            }
+        )
+    return seeded
+
+
 def test_reduple_matches_python_fallback():
     text = "The quick brown fox jumps over the lazy dog."
     expected = reduple_module._python_reduplicate_words(
@@ -126,7 +143,11 @@ def test_redactyl_whitespace_only_text_raises_value_error():
 def _run_python_sequence(text: str, descriptors: list[dict[str, object]], master_seed: int) -> str:
     current = text
     for index, descriptor in enumerate(descriptors):
-        rng_seed = core_module.Gaggle.derive_seed(master_seed, descriptor["name"], index)
+        rng_seed = descriptor.get("seed")
+        if rng_seed is None:
+            rng_seed = core_module.Gaggle.derive_seed(
+                master_seed, descriptor["name"], index
+            )
         rng = random.Random(rng_seed)
         operation = descriptor["operation"]
         op_type = operation["type"]
@@ -163,7 +184,7 @@ def _run_python_sequence(text: str, descriptors: list[dict[str, object]], master
 
 def test_compose_glitchlings_matches_python_pipeline():
     zoo_rust = pytest.importorskip("glitchlings._zoo_rust")
-    descriptors = [
+    raw_descriptors = [
         {"name": "Reduple", "operation": {"type": "reduplicate", "reduplication_rate": 0.4}},
         {"name": "Rushmore", "operation": {"type": "delete", "max_deletion_rate": 0.5}},
         {
@@ -179,6 +200,7 @@ def test_compose_glitchlings_matches_python_pipeline():
     ]
     text = "Guard the vault at midnight"
     master_seed = 404
+    descriptors = _with_descriptor_seeds(raw_descriptors, master_seed)
     expected = _run_python_sequence(text, descriptors, master_seed)
     result = zoo_rust.compose_glitchlings(text, descriptors, master_seed)
     assert result == expected
@@ -186,7 +208,7 @@ def test_compose_glitchlings_matches_python_pipeline():
 
 def test_compose_glitchlings_is_deterministic():
     zoo_rust = pytest.importorskip("glitchlings._zoo_rust")
-    descriptors = [
+    raw_descriptors = [
         {"name": "Reduple", "operation": {"type": "reduplicate", "reduplication_rate": 0.4}},
         {"name": "Rushmore", "operation": {"type": "delete", "max_deletion_rate": 0.3}},
         {
@@ -199,6 +221,7 @@ def test_compose_glitchlings_is_deterministic():
             },
         },
     ]
+    descriptors = _with_descriptor_seeds(raw_descriptors, 777)
     text = "Guard the vault at midnight"
     first = zoo_rust.compose_glitchlings(text, descriptors, 777)
     second = zoo_rust.compose_glitchlings(text, descriptors, 777)
@@ -207,19 +230,23 @@ def test_compose_glitchlings_is_deterministic():
 
 def test_compose_glitchlings_propagates_glitch_errors():
     zoo_rust = pytest.importorskip("glitchlings._zoo_rust")
-    descriptors = [
-        {
-            "name": "Redactyl",
-            "operation": {
-                "type": "redact",
-                "replacement_char": redactyl_module.FULL_BLOCK,
-                "redaction_rate": 1.0,
-                "merge_adjacent": False,
-            },
-        }
-    ]
+    master_seed = 404
+    descriptors = _with_descriptor_seeds(
+        [
+            {
+                "name": "Redactyl",
+                "operation": {
+                    "type": "redact",
+                    "replacement_char": redactyl_module.FULL_BLOCK,
+                    "redaction_rate": 1.0,
+                    "merge_adjacent": False,
+                },
+            }
+        ],
+        master_seed,
+    )
     with pytest.raises(ValueError, match="contains no redactable words"):
-        zoo_rust.compose_glitchlings("   \t", descriptors, 404)
+        zoo_rust.compose_glitchlings("   \t", descriptors, master_seed)
 
 
 def test_gaggle_prefers_rust_pipeline(monkeypatch):
@@ -243,20 +270,29 @@ def test_gaggle_prefers_rust_pipeline(monkeypatch):
     monkeypatch.setattr(redactyl_module, "redact_words", _fail)
     monkeypatch.setattr(scannequin_module, "ocr_artifacts", _fail)
 
-    gaggle = core_module.Gaggle(
-        [
-            reduple_module.Reduple(reduplication_rate=0.4),
-            rushmore_module.Rushmore(max_deletion_rate=0.3),
-            redactyl_module.Redactyl(redaction_rate=0.5, merge_adjacent=True),
-            scannequin_module.Scannequin(error_rate=0.2),
-        ],
-        seed=777,
-    )
+    gaggle_glitchlings = [
+        scannequin_module.Scannequin(error_rate=0.2),
+        reduple_module.Reduple(reduplication_rate=0.4),
+        rushmore_module.Rushmore(max_deletion_rate=0.3),
+        redactyl_module.Redactyl(redaction_rate=0.5, merge_adjacent=True),
+    ]
+    gaggle = core_module.Gaggle(gaggle_glitchlings, seed=777)
 
     text = "Safeguard the archive tonight"
     result = gaggle(text)
     assert calls, "Expected the Rust pipeline to be invoked"
     descriptors = calls[0][1]
+    apply_names = [glitch.name for glitch in gaggle.apply_order]
+    original_names = [glitch.name for glitch in gaggle_glitchlings]
+    assert apply_names != original_names, "Expected Gaggle to reorder glitchlings"
+    expected_seeds = {
+        glitch.name: core_module.Gaggle.derive_seed(777, glitch.name, index)
+        for index, glitch in enumerate(gaggle_glitchlings)
+    }
+    assert [descriptor["seed"] for descriptor in descriptors] == [
+        expected_seeds[descriptor["name"]]
+        for descriptor in descriptors
+    ]
     expected = _run_python_sequence(text, descriptors, 777)
     assert result == expected
 
@@ -280,10 +316,11 @@ def test_gaggle_python_fallback_when_pipeline_disabled(monkeypatch):
 
     text = "Hold the door"
     result = gaggle(text)
-    descriptors = [
+    raw_descriptors = [
         {"name": "Reduple", "operation": {"type": "reduplicate", "reduplication_rate": 0.4}},
         {"name": "Rushmore", "operation": {"type": "delete", "max_deletion_rate": 0.3}},
     ]
+    descriptors = _with_descriptor_seeds(raw_descriptors, 2024)
     expected = _run_python_sequence(text, descriptors, 2024)
     assert result == expected
 

--- a/tests/test_rust_backed_glitchlings.py
+++ b/tests/test_rust_backed_glitchlings.py
@@ -64,6 +64,18 @@ def test_scannequin_matches_python_fallback():
     assert result == expected == "Tlie rn m"
 
 
+@pytest.mark.parametrize("seed", [0, 1, 2, 5, 13])
+def test_scannequin_overlap_candidates_matches_python(seed: int):
+    text = "cl rn li"
+    expected = scannequin_module._python_ocr_artifacts(
+        text,
+        error_rate=1.0,
+        rng=random.Random(seed),
+    )
+    result = scannequin_module.ocr_artifacts(text, error_rate=1.0, seed=seed)
+    assert result == expected
+
+
 def test_redactyl_matches_python_fallback():
     text = "The quick brown fox jumps over the lazy dog."
     expected = redactyl_module._python_redact_words(


### PR DESCRIPTION
## Summary
- remove the generic early return in the Rust apply helper so glitch operations handle empty inputs themselves
- allow the redaction operation to propagate its "no redactable words" error just like the Python implementation

## Testing
- PYO3_PYTHON=/usr/bin/python3.12 cargo test --manifest-path rust/zoo/Cargo.toml
- PYTHONPATH=src .venv/bin/python -m pytest -rs

------
https://chatgpt.com/codex/tasks/task_e_68e147190108833297bec3dd84a5729c