### PR TITLE
Fix OCR artifact ordering parity with Python

### DIFF
--- a/rust/zoo/src/glitch_ops.rs
+++ b/rust/zoo/src/glitch_ops.rs
@@ -300,6 +300,9 @@ impl GlitchOp for OcrArtifactsOp {
         }
 
         let mut order: Vec<usize> = (0..candidates.len()).collect();
+        // We hand-roll Fisher–Yates instead of using helper utilities so the
+        // shuffle mirrors Python's `random.shuffle` exactly. The regression
+        // tests rely on this parity to keep the Rust and Python paths in lockstep.
         for idx in (1..order.len()).rev() {
             let swap_with = rng.rand_index(idx + 1)?;
             order.swap(idx, swap_with);

--- a/rust/zoo/src/glitch_ops.rs
+++ b/rust/zoo/src/glitch_ops.rs
@@ -299,7 +299,11 @@ impl GlitchOp for OcrArtifactsOp {
             return Ok(());
         }
 
-        let order = rng.sample_indices(candidates.len(), candidates.len())?;
+        let mut order: Vec<usize> = (0..candidates.len()).collect();
+        for idx in (1..order.len()).rev() {
+            let swap_with = rng.rand_index(idx + 1)?;
+            order.swap(idx, swap_with);
+        }
         let mut chosen: Vec<(usize, usize, &'static str)> = Vec::new();
         let mut occupied: Vec<(usize, usize)> = Vec::new();
 

--- a/rust/zoo/src/resources.rs
+++ b/rust/zoo/src/resources.rs
@@ -45,7 +45,6 @@ pub static OCR_CONFUSION_TABLE: Lazy<Vec<(&'static str, &'static [&'static str])
                 .iter()
                 .copied()
                 .enumerate()
-                .map(|(index, pair)| (index, pair))
                 .collect();
         entries.sort_by(|a, b| {
             let a_len = a.1 .0.len();

--- a/rust/zoo/src/resources.rs
+++ b/rust/zoo/src/resources.rs
@@ -40,10 +40,21 @@ static BASE_CONFUSION_TABLE: &[(&str, &[&str])] = &[
 /// Sorted confusion pairs reused by glitchling implementations.
 pub static OCR_CONFUSION_TABLE: Lazy<Vec<(&'static str, &'static [&'static str])>> =
     Lazy::new(|| {
-        let mut entries: Vec<(&'static str, &'static [&'static str])> =
-            BASE_CONFUSION_TABLE.iter().copied().collect();
-        entries.sort_by(|a, b| b.0.len().cmp(&a.0.len()).then_with(|| a.0.cmp(b.0)));
-        entries
+        let mut entries: Vec<(usize, (&'static str, &'static [&'static str]))> =
+            BASE_CONFUSION_TABLE
+                .iter()
+                .copied()
+                .enumerate()
+                .map(|(index, pair)| (index, pair))
+                .collect();
+        entries.sort_by(|a, b| {
+            let a_len = a.1 .0.len();
+            let b_len = b.1 .0.len();
+            b_len
+                .cmp(&a_len)
+                .then_with(|| a.0.cmp(&b.0))
+        });
+        entries.into_iter().map(|(_, pair)| pair).collect()
     });
 
 /// Returns the pre-sorted OCR confusion table.

--- a/tests/test_rust_backed_glitchlings.py
+++ b/tests/test_rust_backed_glitchlings.py
@@ -64,6 +64,18 @@ def test_scannequin_matches_python_fallback():
     assert result == expected == "Tlie rn m"
 
 
+@pytest.mark.parametrize("seed", [0, 1, 2, 5, 13])
+def test_scannequin_overlap_candidates_matches_python(seed: int):
+    text = "cl rn li"
+    expected = scannequin_module._python_ocr_artifacts(
+        text,
+        error_rate=1.0,
+        rng=random.Random(seed),
+    )
+    result = scannequin_module.ocr_artifacts(text, error_rate=1.0, seed=seed)
+    assert result == expected
+
+
 def test_redactyl_matches_python_fallback():
     text = "The quick brown fox jumps over the lazy dog."
     expected = redactyl_module._python_redact_words(


### PR DESCRIPTION
## Summary
- keep OCR confusion patterns stable for ties by sorting with their original order
- mirror Python's shuffle in the Rust OCR artifacts op to preserve RNG parity
- add a regression test covering overlapping OCR replacements across seeds

## Testing
- pytest tests/test_rust_backed_glitchlings.py

------
https://chatgpt.com/codex/tasks/task_e_68e17a57f30483329ac57fbf900a52fd