### PR TITLE
Ensure Rust pipeline uses gaggle-derived seeds

### DIFF
--- a/rust/zoo/src/lib.rs
+++ b/rust/zoo/src/lib.rs
@@ -63,6 +63,7 @@ impl<'py> GlitchRng for PythonRngAdapter<'py> {
 #[derive(Debug)]
 struct PyGlitchDescriptor {
     name: String,
+    seed: u64,
     operation: PyGlitchOperation,
 }
 
@@ -73,11 +74,15 @@ impl<'py> FromPyObject<'py> for PyGlitchDescriptor {
             .get_item("name")?
             .ok_or_else(|| PyValueError::new_err("descriptor missing 'name' field"))?
             .extract()?;
+        let seed = dict
+            .get_item("seed")?
+            .ok_or_else(|| PyValueError::new_err("descriptor missing 'seed' field"))?
+            .extract()?;
         let operation = dict
             .get_item("operation")?
             .ok_or_else(|| PyValueError::new_err("descriptor missing 'operation' field"))?
             .extract()?;
-        Ok(Self { name, operation })
+        Ok(Self { name, seed, operation })
     }
 }
 
@@ -257,6 +262,7 @@ fn compose_glitchlings(
             };
             Ok(GlitchDescriptor {
                 name: descriptor.name,
+                seed: descriptor.seed,
                 operation,
             })
         })

--- a/src/glitchlings/zoo/core.py
+++ b/src/glitchlings/zoo/core.py
@@ -297,6 +297,7 @@ class Gaggle(Glitchling):
             _g = g.clone()
             derived_seed = Gaggle.derive_seed(seed, _g.name, idx)
             _g.reset_rng(derived_seed)
+            setattr(_g, "_gaggle_index", idx)
             self.glitchlings[g.level].append(_g)
         self.sort_glitchlings()
 
@@ -360,7 +361,22 @@ class Gaggle(Glitchling):
             operation = builder(glitchling)
             if operation is None:
                 return None
-            descriptors.append({"name": glitchling.name, "operation": operation})
+
+            seed = glitchling.seed
+            if seed is None:
+                index = getattr(glitchling, "_gaggle_index", None)
+                master_seed = self.seed
+                if index is None or master_seed is None:
+                    return None
+                seed = Gaggle.derive_seed(master_seed, glitchling.name, index)
+
+            descriptors.append(
+                {
+                    "name": glitchling.name,
+                    "operation": operation,
+                    "seed": int(seed),
+                }
+            )
 
         return descriptors
 


### PR DESCRIPTION
## Summary
- retain each glitchling's gaggle-derived seed when assembling pipeline descriptors so metadata survives sorting
- extend the PyO3 bridge and Rust pipeline to consume descriptor seeds instead of recomputing them from enumerate order
- update parity tests to annotate descriptors with seeds and cover reordered gaggle execution

## Testing
- pytest tests/test_rust_backed_glitchlings.py
- cargo test *(fails: missing CPython development libraries for linking)*

------
https://chatgpt.com/codex/tasks/task_e_68e17a140e60833299ebcbdcddb8f80c