### PR TITLE
docs: document rust pipeline and dev setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ echo "Beware LLM-written flavor-text" | glitchlings -g mim1c
 
 Use `--help` for a complete breakdown of available options.
 
+## Development
+
+Follow the [development setup guide](docs/development.md) for editable installs, automated tests, and tips on enabling the Rust pipeline while you hack on new glitchlings.
+
 ## Starter 'lings
 
 For maintainability reasons, all `Glitchling` have consented to be given nicknames once they're in your care. See the [Monster Manual](MONSTER_MANUAL.md) for a complete bestiary.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,69 @@
+# Glitchlings development setup
+
+This guide walks through preparing a local development environment, running the automated checks, and exercising the optional Rust acceleration layer.
+
+## Prerequisites
+
+- Python 3.12+
+- `pip` and a virtual environment tool of your choice (the examples below use `python -m venv`)
+- [Optional] A Rust toolchain (`rustup` or system packages) and [`maturin`](https://www.maturin.rs/) for compiling the PyO3 extensions
+
+## Install the project
+
+1. Clone the repository and create an isolated environment:
+
+   ```bash
+   git clone https://github.com/osoleve/glitchlings.git
+   cd glitchlings
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+
+2. Install the package in editable mode with the development dependencies:
+
+   ```bash
+   pip install -e .[dev]
+   ```
+
+   Add the `prime` extra (`pip install -e .[dev,prime]`) when you need the Prime Intellect integration and its `verifiers` dependency.
+
+3. If you plan to use the Jargoyle glitchling, download the WordNet corpus once per machine:
+
+   ```bash
+   python -m nltk.downloader wordnet
+   ```
+
+## Run the test suite
+
+Execute the automated tests from the repository root:
+
+```bash
+pytest
+```
+
+The suite covers determinism guarantees, dataset integrations, and parity between Python and Rust implementations. When the WordNet corpus is unavailable, the Jargoyle-specific tests skip automatically.
+
+## Optional Rust acceleration
+
+Glitchlings ships PyO3 extensions that accelerate Typogre, Mim1c, Reduple, Rushmore, Redactyl, and Scannequin. Compile them with `maturin` and toggle the feature flag to exercise the new Rust pipeline:
+
+```bash
+# Compile the shared Rust crate (rerun after Rust or Python updates)
+maturin develop -m rust/zoo/Cargo.toml
+
+# Enable the fast path before importing glitchlings
+export GLITCHLINGS_RUST_PIPELINE=1
+```
+
+Unset the environment variable (or set it to `0`/`false`) to fall back to the pure-Python orchestrator. The test suite automatically covers both code paths—re-run `pytest` with and without the flag to verify new changes across implementations.
+
+## Additional tips
+
+- Regenerate the optional typogre-specific extension when editing files under `rust/typogre/`:
+
+  ```bash
+  maturin develop -m rust/typogre/Cargo.toml
+  ```
+
+- Use `python -m glitchlings --help` to smoke-test CLI changes quickly.
+- Check `docs/index.md` for end-user guidance—keep it in sync with behaviour changes when you ship new glitchlings or orchestration features.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,9 @@ Welcome to the Glitchlings field manual! This GitHub Pages-ready guide explains 
 
 1. [Installation](#installation)
 2. [Quickstart](#quickstart)
-3. [The Gaggle orchestrator](#the-gaggle-orchestrator)
-4. [Glitchling reference](#glitchling-reference)
+3. [Rust pipeline acceleration (opt-in)](#rust-pipeline-acceleration-opt-in)
+4. [The Gaggle orchestrator](#the-gaggle-orchestrator)
+5. [Glitchling reference](#glitchling-reference)
    - [Typogre](#typogre)
    - [Mim1c](#mim1c)
    - [Reduple](#reduple)
@@ -15,11 +16,11 @@ Welcome to the Glitchlings field manual! This GitHub Pages-ready guide explains 
    - [Redactyl](#redactyl)
    - [Jargoyle](#jargoyle)
    - [Scannequin](#scannequin)
-5. [Dataset workflows](#dataset-workflows)
-6. [Prime Intellect integration](#prime-intellect-integration)
-7. [Ensuring determinism](#ensuring-determinism)
-8. [Testing checklist](#testing-checklist)
-9. [Additional resources](#additional-resources)
+6. [Dataset workflows](#dataset-workflows)
+7. [Prime Intellect integration](#prime-intellect-integration)
+8. [Ensuring determinism](#ensuring-determinism)
+9. [Testing checklist](#testing-checklist)
+10. [Additional resources](#additional-resources)
 
 ## Installation
 
@@ -48,6 +49,8 @@ pip install -e .
 ```
 
 If you plan to experiment with the PyO3 acceleration crates, install `maturin` and run `maturin develop` from each crate directory inside the `rust/` folder to compile the optional Rust fast paths.
+
+Looking for a complete development workflow (virtual environments, test suite, and Rust tips)? Consult the [development setup guide](development.md).
 
 ## Quickstart
 
@@ -84,6 +87,28 @@ echo "Beware LLM-written flavor-text" | glitchlings -g mim1c
 ```
 
 Append `--diff` to render a unified diff comparing the original and corrupted outputs. Combine it with `--color=always` in terminals that support ANSI colours to highlight changes more clearly.
+
+## Rust pipeline acceleration (opt-in)
+
+The refactored Rust pipeline batches compatible glitchlings in a single PyO3 call so large datasets spend less time bouncing between Python and Rust. Enable it behind the feature flag when the compiled extension is available:
+
+1. Compile the Rust crate once per environment:
+
+   ```bash
+   maturin develop -m rust/zoo/Cargo.toml
+   ```
+
+   Re-run the command after switching Python versions or pulling changes that touch the Rust sources.
+
+2. Export the feature flag before importing `glitchlings`:
+
+   ```bash
+   export GLITCHLINGS_RUST_PIPELINE=1
+   ```
+
+   Any truthy value (`1`, `true`, `yes`, `on`) enables the fast path. When the flag is unset or the extension is missing, `Gaggle` transparently falls back to the pure-Python pipeline.
+
+The orchestrator automatically groups Typogre, Mim1c, Reduple, Rushmore, Redactyl, and Scannequin into the accelerated wave order while leaving incompatible glitchlings (or custom implementations) on the legacy path.
 
 ## The Gaggle orchestrator
 
@@ -264,5 +289,6 @@ python -c "import nltk; nltk.download('wordnet')"
 
 - [Monster Manual](../MONSTER_MANUAL.md) – complete bestiary with flavour text.
 - [Repository README](../README.md) – project overview and ASCII ambience.
+- [Development setup](development.md) – local environment, testing, and Rust acceleration guide.
 
 Once the `/docs` folder is published through GitHub Pages, this guide becomes the landing site for your glitchling adventures.


### PR DESCRIPTION
## Summary
- add a dedicated development setup guide covering editable installs, tests, and Rust acceleration
- document the Rust pipeline feature flag in the main docs and link to the setup guide
- point the README to the docs-based development instructions

## Testing
- not run (docs-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e183c7c4708332b379eace2b862e3a