### PR TITLE
Skip Prime DLC tests when verifiers extra is missing

### DIFF
--- a/tests/test_prime_echo_chamber.py
+++ b/tests/test_prime_echo_chamber.py
@@ -3,6 +3,11 @@ import pytest
 datasets = pytest.importorskip("datasets")
 Dataset = datasets.Dataset
 
+# The Prime DLC depends on the optional ``verifiers`` package. Skip these
+# tests entirely when it isn't installed (e.g. in wheel builds that don't
+# request the ``prime`` extra).
+pytest.importorskip("verifiers")
+
 from glitchlings.zoo.core import AttackWave, Gaggle, Glitchling
 from glitchlings.dlc import prime
 


### PR DESCRIPTION
## Summary
- skip the Prime DLC test module when the optional `verifiers` dependency is unavailable so wheel builds without the `prime` extra no longer fail

## Testing
- pytest tests/test_prime_echo_chamber.py

------
https://chatgpt.com/codex/tasks/task_e_68e1b484af1883328e1d10b5f3a2dd0a