### PR TITLE
Fix TestPyPI build by excluding Rust target artifacts

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,4 @@
-recursive-include rust *
+recursive-include rust *.rs *.toml *.lock
+prune rust/target
+prune rust/typogre/target
+prune rust/zoo/target


### PR DESCRIPTION
## Summary
- restrict the sdist to Rust source files and prune target directories so compiled artifacts from cibuildwheel builds do not ship in the archive and break TestPyPI publishing

## Testing
- GLITCHLINGS_RUST_PIPELINE=1 pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e1b724f870833289467dcb48c9a317