### PR TITLE
Add helper script for retrying TestPyPI publishes

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -67,3 +67,4 @@ Unset the environment variable (or set it to `0`/`false`) to fall back to the pu
 
 - Use `python -m glitchlings --help` to smoke-test CLI changes quickly.
 - Check `docs/index.md` for end-user guidance—keep it in sync with behaviour changes when you ship new glitchlings or orchestration features.
+- When a TestPyPI publish fails, sync `dev` with `trunk` and recreate the release tag to trigger the workflow again. A helper script lives at `scripts/retry_testpypi_release.sh`—pass it the tag name (`./scripts/retry_testpypi_release.sh v1.2.3`) to fast-forward `dev`, delete and recreate the tag, and push both updates.

--- a/scripts/retry_testpypi_release.sh
+++ b/scripts/retry_testpypi_release.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Synchronise the dev branch with trunk and recreate a release tag to retry the TestPyPI publish workflow.
+#
+# Usage:
+#   scripts/retry_testpypi_release.sh <tag>
+#
+# The script assumes that:
+#   * `trunk` is the canonical branch.
+#   * `dev` is the branch that triggers the TestPyPI workflow.
+#   * `origin` is the remote to update.
+#
+# Override the defaults by exporting REMOTE, TRUNK_BRANCH, or DEV_BRANCH.
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <tag>" >&2
+    exit 1
+fi
+
+tag="$1"
+remote="${REMOTE:-origin}"
+trunk_branch="${TRUNK_BRANCH:-trunk}"
+dev_branch="${DEV_BRANCH:-dev}"
+
+# Ensure we have the latest refs from the remote.
+git fetch "${remote}" --prune
+
+# Make sure the local trunk matches the remote state.
+if git rev-parse --verify --quiet "refs/heads/${trunk_branch}" > /dev/null; then
+    git checkout "${trunk_branch}"
+else
+    git checkout -b "${trunk_branch}" "${remote}/${trunk_branch}"
+fi
+git pull --ff-only "${remote}" "${trunk_branch}"
+
+# Fast-forward dev to the refreshed trunk.
+if git rev-parse --verify --quiet "refs/heads/${dev_branch}" > /dev/null; then
+    git checkout "${dev_branch}"
+else
+    git checkout -b "${dev_branch}" "${remote}/${dev_branch}" 2>/dev/null || \
+        git checkout -b "${dev_branch}" "${trunk_branch}"
+fi
+git merge --ff-only "${trunk_branch}"
+
+git push "${remote}" "${dev_branch}"
+
+# Delete the tag locally if it already exists.
+if git rev-parse --verify --quiet "refs/tags/${tag}" > /dev/null; then
+    git tag -d "${tag}"
+fi
+
+# Remove the tag from the remote. Ignore errors if the tag does not exist remotely.
+git push "${remote}" ":refs/tags/${tag}" || true
+
+# Recreate the tag from the trunk branch.
+git checkout "${trunk_branch}"
+git tag "${tag}"
+
+git push "${remote}" "${tag}"


### PR DESCRIPTION
## Summary
- add a helper script that synchronises `dev` with `trunk` and recreates a release tag to re-run the TestPyPI workflow
- document the retry flow in the development guide for future releases

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68e1c2c9aab08332a3f05b20a6c15780