### PR TITLE
Handle existing TestPyPI releases

### DIFF
--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -67,3 +67,4 @@ jobs:
           packages-dir: dist
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          skip-existing: true


### PR DESCRIPTION
## Summary
- allow the TestPyPI publish workflow to skip versions that already exist on TestPyPI

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68e2c28cebd48332bad8c0c7f46b08b6