### PR TITLE
Ensure WordNet setup for tests and align rust fallbacks

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ Welcome to the Glitchlings field manual! This GitHub Pages-ready guide explains 
 8. [Ensuring determinism](#ensuring-determinism)
 9. [Testing checklist](#testing-checklist)
 10. [Additional resources](#additional-resources)
+    - [Keyboard layout reference](keyboard-layouts.md)
 
 ## Installation
 
@@ -290,5 +291,6 @@ python -c "import nltk; nltk.download('wordnet')"
 - [Monster Manual](../MONSTER_MANUAL.md) – complete bestiary with flavour text.
 - [Repository README](../README.md) – project overview and ASCII ambience.
 - [Development setup](development.md) – local environment, testing, and Rust acceleration guide.
+- [Keyboard layout reference](keyboard-layouts.md) – available adjacency maps for Typogre and related features.
 
 Once the `/docs` folder is published through GitHub Pages, this guide becomes the landing site for your glitchling adventures.

--- a/docs/keyboard-layouts.md
+++ b/docs/keyboard-layouts.md
@@ -1,0 +1,30 @@
+# Keyboard Layout Reference
+
+Glitchlings includes several keyboard adjacency maps that fuel Typogre and any
+behaviour that depends on "nearby" keys. Layouts live in
+`glitchlings.util.KEYNEIGHBORS` and each entry exposes a mapping from a key to
+the characters that surround it on the corresponding physical keyboard.
+
+The following layouts are currently bundled:
+
+| Layout name | Region / focus | Notes |
+| --- | --- | --- |
+| `CURATOR_QWERTY` | Project-specific curation | Includes numeric neighbours for symbol-heavy glitches. |
+| `QWERTY` | US English | Standard ANSI layout. |
+| `DVORAK` | US English (Dvorak) | Optimised vowel/consonant arrangement. |
+| `COLEMAK` | US English (Colemak) | Ergonomic compromise between QWERTY and Dvorak. |
+| `AZERTY` | France / Belgium | ISO layout featuring accented characters such as `é` and `à`. |
+| `QWERTZ` | Germany / Central Europe | Adds umlauts (`ä`, `ö`, `ü`) and `ß`. |
+| `SPANISH_QWERTY` | Spain | Provides dedicated keys for `ñ`, acute accents, and inverted punctuation. |
+| `SWEDISH_QWERTY` | Sweden / Nordic | Includes `å`, `ä`, and `ö` alongside the `<` dead-key column. |
+
+To use a layout, import `KEYNEIGHBORS` and select the desired mapping:
+
+```python
+from glitchlings.util import KEYNEIGHBORS
+neighbors = getattr(KEYNEIGHBORS, "QWERTZ")
+print(neighbors["z"])  # -> list of adjacent characters
+```
+
+Each mapping only contains lowercase keys; call `.lower()` on user input before
+looking up neighbours.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ prime = ["verifiers>=0.1.3.post0"]
 dev = [
     "pytest>=8.0.0",
     "hypothesis>=6.140.0",
+    "nltk>=3.9.1",
 ]
 
 [build-system]

--- a/rust/zoo/src/typogre.rs
+++ b/rust/zoo/src/typogre.rs
@@ -224,7 +224,7 @@ pub(crate) fn fatfinger(
     }
 
     let length = chars.len();
-    let mut max_changes = (length as f64 * max_change_rate).floor() as usize;
+    let mut max_changes = (length as f64 * max_change_rate).ceil() as usize;
     if max_changes < 1 {
         max_changes = 1;
     }

--- a/src/glitchlings/main.py
+++ b/src/glitchlings/main.py
@@ -20,19 +20,16 @@ from .zoo import (
     scannequin,
     summon,
 )
+from .zoo.jargoyle import dependencies_available as _jargoyle_available
 
+
+_BUILTIN_GLITCHLINGS: list[Glitchling] = [typogre, mim1c]
+if _jargoyle_available():
+    _BUILTIN_GLITCHLINGS.append(jargoyle)
+_BUILTIN_GLITCHLINGS.extend([reduple, rushmore, redactyl, scannequin])
 
 BUILTIN_GLITCHLINGS: dict[str, Glitchling] = {
-    g.name.lower(): g
-    for g in [
-        typogre,
-        mim1c,
-        jargoyle,
-        reduple,
-        rushmore,
-        redactyl,
-        scannequin,
-    ]
+    g.name.lower(): g for g in _BUILTIN_GLITCHLINGS
 }
 
 DEFAULT_GLITCHLING_NAMES: list[str] = list(BUILTIN_GLITCHLINGS.keys())

--- a/src/glitchlings/util/__init__.py
+++ b/src/glitchlings/util/__init__.py
@@ -141,6 +141,36 @@ _register_layout(
     ),
 )
 
+_register_layout(
+    "QWERTZ",
+    (
+        "^1234567890ß´",
+        " qwertzuiopü+",
+        "  asdfghjklöä#",
+        "   yxcvbnm,.-",
+    ),
+)
+
+_register_layout(
+    "SPANISH_QWERTY",
+    (
+        "º1234567890'¡",
+        " qwertyuiop´+",
+        "  asdfghjklñ´",
+        "   <zxcvbnm,.-",
+    ),
+)
+
+_register_layout(
+    "SWEDISH_QWERTY",
+    (
+        "§1234567890+´",
+        " qwertyuiopå¨",
+        "  asdfghjklöä'",
+        "   <zxcvbnm,.-",
+    ),
+)
+
 
 class KeyNeighbors:
     def __init__(self) -> None:

--- a/src/glitchlings/zoo/redactyl.py
+++ b/src/glitchlings/zoo/redactyl.py
@@ -82,7 +82,9 @@ def redact_words(
     if rng is None:
         rng = random.Random(seed)
 
-    if _redact_words_rust is not None:
+    use_rust = _redact_words_rust is not None and isinstance(merge_adjacent, bool)
+
+    if use_rust:
         return _redact_words_rust(
             text,
             replacement_char,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,17 @@
 import pytest
 
 from glitchlings import SAMPLE_TEXT
+from glitchlings.zoo.jargoyle import ensure_wordnet
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _wordnet_ready() -> None:
+    """Ensure the NLTK WordNet corpus is available for the test suite."""
+
+    try:
+        ensure_wordnet()
+    except RuntimeError as exc:  # pragma: no cover - only triggered on env issues
+        pytest.fail(f"WordNet setup failed for tests: {exc}")
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_glitchlings_determinism.py
+++ b/tests/test_glitchlings_determinism.py
@@ -1,8 +1,6 @@
 from functools import partial
 from typing import cast
 
-import pytest
-
 from glitchlings import (
     typogre,
     mim1c,
@@ -13,15 +11,6 @@ from glitchlings import (
     scannequin,
 )
 from glitchlings.zoo.core import AttackWave, Glitchling
-from glitchlings.zoo.jargoyle import ensure_wordnet
-
-
-@pytest.fixture(scope="module", autouse=True)
-def _wordnet_ready() -> None:
-    try:  # pragma: no cover - failures propagate loudly during testing
-        ensure_wordnet()
-    except RuntimeError as exc:  # pragma: no cover - only hit if download fails
-        pytest.fail(f"WordNet unavailable for determinism tests: {exc}")
 
 
 def _twice(fn, text: str, seed: int = 42) -> tuple[str, str]:

--- a/tests/test_jargoyle.py
+++ b/tests/test_jargoyle.py
@@ -1,16 +1,6 @@
 from __future__ import annotations
 
-import pytest
-
-from glitchlings.zoo.jargoyle import ensure_wordnet, substitute_random_synonyms
-
-
-@pytest.fixture(scope="module", autouse=True)
-def _wordnet_ready() -> None:
-    try:  # pragma: no cover - only exercised when downloads fail
-        ensure_wordnet()
-    except RuntimeError as exc:  # pragma: no cover - failure propagates clearly
-        pytest.fail(f"WordNet unavailable for jargoyle tests: {exc}")
+from glitchlings.zoo.jargoyle import substitute_random_synonyms
 
 
 def _clean_tokens(text: str) -> list[str]:

--- a/tests/test_keyboard_layouts.py
+++ b/tests/test_keyboard_layouts.py
@@ -5,7 +5,15 @@ from glitchlings.util import KEYNEIGHBORS
 
 def test_standard_layouts_cover_alphabet() -> None:
     letters = set(string.ascii_lowercase)
-    for layout_name in ("QWERTY", "DVORAK", "COLEMAK", "AZERTY"):
+    for layout_name in (
+        "QWERTY",
+        "DVORAK",
+        "COLEMAK",
+        "AZERTY",
+        "QWERTZ",
+        "SPANISH_QWERTY",
+        "SWEDISH_QWERTY",
+    ):
         layout = getattr(KEYNEIGHBORS, layout_name)
         missing = letters - set(layout)
         assert not missing, f"{layout_name} missing: {sorted(missing)}"
@@ -23,3 +31,12 @@ def test_layout_neighbor_expectations() -> None:
 
     colemak = getattr(KEYNEIGHBORS, "COLEMAK")
     assert {"j", "n"} <= set(colemak["h"])
+
+    qwertz = getattr(KEYNEIGHBORS, "QWERTZ")
+    assert {"t", "u"} <= set(qwertz["z"])
+
+    spanish = getattr(KEYNEIGHBORS, "SPANISH_QWERTY")
+    assert {"s", "d", "x"} <= set(spanish["z"])
+
+    swedish = getattr(KEYNEIGHBORS, "SWEDISH_QWERTY")
+    assert {"å", "ö"} <= set(swedish["p"])


### PR DESCRIPTION
## Summary
- add a session-wide pytest fixture that forces the WordNet corpus to be available instead of skipping jargoyle checks
- include nltk in the dev extra so local test environments install the dependency automatically
- fall back from Rust fast paths when they cannot handle parameters and synchronize typogre's change count rounding with the Python implementation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3f45dae148332aea47c2ff4e81f55