### PR TITLE
Make Prime tests independent of optional dependencies

### DIFF
--- a/tests/test_prime_echo_chamber.py
+++ b/tests/test_prime_echo_chamber.py
@@ -35,11 +35,6 @@ jargoyle._ensure_wordnet = _no_op_ensure_wordnet
 jargoyle._wordnet_ready = True
 
 
-@pytest.fixture(scope="session", autouse=True)
-def _wordnet_ready():
-    """Override the default WordNet preparation for this module."""
-
-    return None
 
 
 class FakeDataset:


### PR DESCRIPTION
## Summary
- stub out the optional verifiers and wordnet dependencies inside the Prime DLC tests so they run without extras
- replace Hugging Face dataset usage with a lightweight fake dataset implementation to satisfy Gaggle expectations
- ensure Damerau-Levenshtein helper tests continue to cover varied input types

## Testing
- pytest tests/test_prime_echo_chamber.py

------
https://chatgpt.com/codex/tasks/task_e_68e40189e4e48332aa78123b856eb7ca