### PR TITLE
docs: relocate usage guidance to docs index

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,22 +53,10 @@ print(gaggle(SAMPLE_TEXT))
 
 ## Usage
 
-Glitchlings slot into evaluation pipelines just as easily as they corrupt stray strings.
-
-- **Direct invocation** – Instantiate a glitchling (or `Gaggle`) and call it on strings, iterables, or datasets. Keep the seed stable to make every run deterministic.
-- **Dataset corruption** – After ``import glitchlings.dlc.huggingface``, call ``Dataset.glitch(...)`` (or a `Gaggle`'s `.corrupt_dataset`) to perturb a Hugging Face `datasets.Dataset` and return a corrupted copy for training or evaluation.
-
-### Rust pipeline acceleration (opt-in)
-
-The refactored Rust pipeline can execute multiple glitchlings without
-bouncing back through Python, but it is gated behind a feature flag so
-teams can roll it out gradually. After compiling the Rust extension
-(`python -m cibuildwheel --output-dir dist`) set
-`GLITCHLINGS_RUST_PIPELINE=1` (or `true`, `yes`, `on`) before importing
-`glitchlings`. When the flag is set and the extension is available,
-`Gaggle` automatically batches compatible glitchlings into the Rust
-pipeline; otherwise it transparently falls back to the legacy Python
-loop.
+Need detailed usage patterns, dataset workflows, or tips for enabling the
+Rust accelerator? Consult the [Glitchlings Usage Guide](docs/index.md)
+for end-to-end instructions spanning the Python API, CLI, Hugging Face
+integrations, and the feature-flagged Rust pipeline.
 
 ### Prime Intellect environments
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,6 +72,11 @@ print(gaggle(SAMPLE_TEXT))
 
 All glitchlings are deterministic: pass a `seed` during construction (or on the enclosing `Gaggle`) to make the chaos reproducible.
 
+Glitchlings slot neatly into existing pipelines:
+
+- **Direct invocation** – Instantiate a glitchling (or `Gaggle`) and call it on strings, iterables, or datasets. Keep the seed stable to reproduce every run.
+- **Dataset corruption** – After ``import glitchlings.dlc.huggingface`` registers the extension, call ``Dataset.glitch(...)`` (or a `Gaggle`'s `.corrupt_dataset`) to perturb a Hugging Face `datasets.Dataset` and return a corrupted copy for training or evaluation.
+
 ### Command line interface
 
 Prefer not to touch Python? The `glitchlings` CLI exposes the same functionality:


### PR DESCRIPTION
## Summary
- streamline the README usage section by pointing readers to the dedicated usage guide
- document direct invocation and dataset corruption workflows in docs/index.md alongside the existing Rust accelerator details

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e40829ae48833283c8092a22499339