### PR TITLE
Relax Python requirement to 3.10

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Treat this handbook as the default guidance for any work in the repo.
 - **Top-level docs** – `README.md` introduces the project and CLI, `MONSTER_MANUAL.md` serves as the glitchling bestiary.
 
 ## Coding Conventions
-- Target **Python 3.12+** (see `pyproject.toml`).
+- Target **Python 3.10+** (see `pyproject.toml`).
 - Follow the import order used in the package: standard library, third-party, then local modules.
 - Every new glitchling must:
   - Subclass `Glitchling`, setting `scope` and `order` via `AttackWave` / `AttackOrder` from `core.py`.

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,7 +4,7 @@ This guide walks through preparing a local development environment, running the 
 
 ## Prerequisites
 
-- Python 3.12+
+- Python 3.10+
 - `pip` and a virtual environment tool of your choice (the examples below use `python -m venv`)
 - [Optional] A Rust toolchain (`rustup` or system packages) and [`maturin`](https://www.maturin.rs/) for compiling the PyO3 extensions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "glitchlings"
 version = "0.2.1"
 description = "Monsters for your language games."
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 
 dependencies = [
     "confusable-homoglyphs>=3.3.1",
@@ -22,6 +22,8 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Rust",
     "Operating System :: MacOS :: MacOS X",

--- a/rust/zoo/build.rs
+++ b/rust/zoo/build.rs
@@ -23,7 +23,13 @@ fn configured_python() -> Option<OsString> {
 }
 
 fn detect_python() -> Option<OsString> {
-    const CANDIDATES: &[&str] = &["python3.12", "python3", "python"];
+    const CANDIDATES: &[&str] = &[
+        "python3.12",
+        "python3.11",
+        "python3.10",
+        "python3",
+        "python",
+    ];
 
     for candidate in CANDIDATES {
         let status = Command::new(candidate)


### PR DESCRIPTION
## Summary
- lower the package's Python requirement to 3.10 and advertise supported versions in the classifiers
- expand the Rust build helper's interpreter detection to cover Python 3.10–3.12
- update contributor guidance to reference the new minimum Python version

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e471bbb11c83328f7c70d0377201bd