### PR TITLE
Dev

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
-recursive-include rust *.rs *.toml *.lock
+recursive-include rust *.rs *.toml *.lock *.tsv
+recursive-include src/glitchlings/zoo *.tsv
 prune rust/target
 prune rust/zoo/target

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,10 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 package-dir = {"" = "src"}
+include-package-data = true
+
+[tool.setuptools.package-data]
+"glitchlings.zoo" = ["ocr_confusions.tsv"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/rust/zoo/assets/ocr_confusions.tsv
+++ b/rust/zoo/assets/ocr_confusions.tsv
@@ -1,0 +1,30 @@
+# Source  Replacements (space-separated)
+li h
+h li
+rn m
+m rn
+cl d
+d cl
+I l
+l I 1
+1 l I
+0 O
+O 0
+B 8
+8 B
+S 5
+5 S
+Z 2
+2 Z
+G 6
+6 G
+“ "
+” "
+‘ '
+’ '
+— -
+– -
+vv w
+w vv
+ri n
+n ri

--- a/rust/zoo/build.rs
+++ b/rust/zoo/build.rs
@@ -1,7 +1,12 @@
+use std::env;
 use std::ffi::{OsStr, OsString};
+use std::fs;
+use std::io::{self, ErrorKind};
+use std::path::PathBuf;
 use std::process::Command;
 
 fn main() {
+    prepare_confusion_table().expect("failed to stage OCR confusion table for compilation");
     pyo3_build_config::add_extension_module_link_args();
 
     if let Some(python) = configured_python() {
@@ -82,3 +87,48 @@ fn query_python(python: &OsStr, command: &str) -> Option<String> {
     let value = String::from_utf8(output.stdout).ok()?;
     Some(value)
 }
+
+fn prepare_confusion_table() -> io::Result<()> {
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("missing manifest dir"));
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("missing OUT_DIR"));
+
+    let repo_path = manifest_dir.join("../../src/glitchlings/zoo/ocr_confusions.tsv");
+    let packaged_path = manifest_dir.join("assets/ocr_confusions.tsv");
+    println!("cargo:rerun-if-changed={}", packaged_path.display());
+
+    let source_path = if repo_path.exists() {
+        println!("cargo:rerun-if-changed={}", repo_path.display());
+        if packaged_path.exists() {
+            let repo_bytes = fs::read(&repo_path)?;
+            let packaged_bytes = fs::read(&packaged_path)?;
+            if repo_bytes != packaged_bytes {
+                return Err(io::Error::new(
+                    ErrorKind::Other,
+                    format!(
+                        "OCR confusion table at {} is out of sync with {}",
+                        packaged_path.display(),
+                        repo_path.display()
+                    ),
+                ));
+            }
+        }
+        repo_path
+    } else {
+        if !packaged_path.exists() {
+            return Err(io::Error::new(
+                ErrorKind::NotFound,
+                format!(
+                    "missing OCR confusion table; looked for {} and {}",
+                    repo_path.display(),
+                    packaged_path.display()
+                ),
+            ));
+        }
+        packaged_path
+    };
+
+    fs::create_dir_all(&out_dir)?;
+    fs::copy(&source_path, out_dir.join("ocr_confusions.tsv"))?;
+    Ok(())
+}
+

--- a/rust/zoo/src/resources.rs
+++ b/rust/zoo/src/resources.rs
@@ -1,10 +1,7 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
 
-const RAW_OCR_CONFUSIONS: &str = include_str!(concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/../../src/glitchlings/zoo/ocr_confusions.tsv"
-));
+const RAW_OCR_CONFUSIONS: &str = include_str!(concat!(env!("OUT_DIR"), "/ocr_confusions.tsv"));
 
 /// Precompiled regex removing spaces before punctuation characters.
 pub static SPACE_BEFORE_PUNCTUATION: Lazy<Regex> =


### PR DESCRIPTION
This pull request updates the minimum required Python version for the project from 3.12 to 3.10 across documentation, configuration, and build scripts. This change broadens compatibility for users and contributors who may not have the latest Python version installed. The most important changes are grouped below:

**Documentation and User Guidance**

* Updated all documentation files (`AGENTS.md`, `README.md`, `docs/development.md`) to reflect Python 3.10+ as the minimum required version instead of 3.12+. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L26-R26) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R39-R40) [[3]](diffhunk://#diff-97db29a7915320e63d41d38a0440360a87055ee8ed03757aa263116dbbb4aabeL7-R7)

**Configuration and Packaging**

* Changed the `requires-python` field in `pyproject.toml` to `>=3.10` and added explicit classifiers for Python 3.10 and 3.11 to clarify supported versions. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L6-R6) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R25-R26)

**Build System**

* Modified the Rust build script (`rust/zoo/build.rs`) to detect and support Python 3.10 and 3.11 in addition to 3.12, improving compatibility for local builds.