### PR TITLE
Test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Treat this handbook as the default guidance for any work in the repo.
 - **Top-level docs** – `README.md` introduces the project and CLI, `MONSTER_MANUAL.md` serves as the glitchling bestiary.
 
 ## Coding Conventions
-- Target **Python 3.12+** (see `pyproject.toml`).
+- Target **Python 3.10+** (see `pyproject.toml`).
 - Follow the import order used in the package: standard library, third-party, then local modules.
 - Every new glitchling must:
   - Subclass `Glitchling`, setting `scope` and `order` via `AttackWave` / `AttackOrder` from `core.py`.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ After all, what good is general intelligence if it can't handle a little chaos?
 pip install -U glitchlings
 ```
 
+> Glitchlings requires Python 3.10 or newer.
+
 ```python
 from glitchlings import Gaggle, SAMPLE_TEXT, Typogre, Mim1c, Reduple, Rushmore
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,7 +4,7 @@ This guide walks through preparing a local development environment, running the 
 
 ## Prerequisites
 
-- Python 3.12+
+- Python 3.10+
 - `pip` and a virtual environment tool of your choice (the examples below use `python -m venv`)
 - [Optional] A Rust toolchain (`rustup` or system packages) and [`maturin`](https://www.maturin.rs/) for compiling the PyO3 extensions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "glitchlings"
 version = "0.2.2"
 description = "Monsters for your language games."
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 
 dependencies = [
     "confusable-homoglyphs>=3.3.1",
@@ -22,6 +22,8 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Rust",
     "Operating System :: MacOS :: MacOS X",

--- a/rust/zoo/build.rs
+++ b/rust/zoo/build.rs
@@ -23,7 +23,13 @@ fn configured_python() -> Option<OsString> {
 }
 
 fn detect_python() -> Option<OsString> {
-    const CANDIDATES: &[&str] = &["python3.12", "python3", "python"];
+    const CANDIDATES: &[&str] = &[
+        "python3.12",
+        "python3.11",
+        "python3.10",
+        "python3",
+        "python",
+    ];
 
     for candidate in CANDIDATES {
         let status = Command::new(candidate)


### PR DESCRIPTION
This pull request updates the minimum supported Python version for the project from 3.12 to 3.10. The change is reflected across documentation, configuration files, and build scripts to ensure consistency and clarity for users and developers.

Python version support updates:

* Updated the minimum required Python version in `pyproject.toml` from `>=3.12` to `>=3.10`, and added classifiers for Python 3.10 and 3.11 to indicate official support. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L6-R6) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R25-R26)
* Changed documentation references in `AGENTS.md`, `README.md`, and `docs/development.md` to specify Python 3.10+ as the minimum requirement. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L26-R26) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R39-R40) [[3]](diffhunk://#diff-97db29a7915320e63d41d38a0440360a87055ee8ed03757aa263116dbbb4aabeL7-R7)
* Modified the Python detection logic in `rust/zoo/build.rs` to include `python3.11` and `python3.10` as candidates for the build process, improving compatibility with more environments.