### PR TITLE
Fix TestPyPI workflow authentication fallback

### DIFF
--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -62,12 +62,22 @@ jobs:
           path: dist
           merge-multiple: true
 
-      - name: Publish to TestPyPI
+      - name: Publish to TestPyPI with API token
+        if: ${{ secrets.TEST_PYPI_API_TOKEN != '' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: dist
           user: __token__
-          # password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          skip-existing: true
+
+      - name: Publish to TestPyPI via Trusted Publishing
+        if: ${{ secrets.TEST_PYPI_API_TOKEN == '' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: dist
+          user: __token__
           skip-existing: true
 


### PR DESCRIPTION
## Summary
- allow the TestPyPI publish job to use an API token when provided and fall back to trusted publishing otherwise

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e67cbd20d4833298d3e65dc65fc1b8