### PR TITLE
Optimize Rust redaction pipeline

### DIFF
--- a/rust/zoo/src/resources.rs
+++ b/rust/zoo/src/resources.rs
@@ -95,8 +95,8 @@ pub fn split_with_separators(text: &str) -> Vec<String> {
     tokens
 }
 
-/// Splits a word into leading punctuation, core token, and trailing punctuation.
-pub fn split_affixes(word: &str) -> (String, String, String) {
+/// Returns the byte bounds of the core token (excluding prefix/suffix punctuation).
+pub fn affix_bounds(word: &str) -> Option<(usize, usize)> {
     let mut start_index: Option<usize> = None;
     let mut end_index = 0;
 
@@ -109,11 +109,16 @@ pub fn split_affixes(word: &str) -> (String, String, String) {
         }
     }
 
-    match start_index {
-        Some(start) => (
+    start_index.map(|start| (start, end_index))
+}
+
+/// Splits a word into leading punctuation, core token, and trailing punctuation.
+pub fn split_affixes(word: &str) -> (String, String, String) {
+    match affix_bounds(word) {
+        Some((start, end)) => (
             word[..start].to_string(),
-            word[start..end_index].to_string(),
-            word[end_index..].to_string(),
+            word[start..end].to_string(),
+            word[end..].to_string(),
         ),
         None => (word.to_string(), String::new(), String::new()),
     }

--- a/rust/zoo/src/typogre.rs
+++ b/rust/zoo/src/typogre.rs
@@ -11,9 +11,7 @@ fn layout_cache() -> &'static RwLock<CachedLayouts> {
     CACHE.get_or_init(|| RwLock::new(HashMap::new()))
 }
 
-fn extract_layout_map(
-    layout: &Bound<'_, PyDict>,
-) -> PyResult<Arc<HashMap<String, Vec<String>>>> {
+fn extract_layout_map(layout: &Bound<'_, PyDict>) -> PyResult<Arc<HashMap<String, Vec<String>>>> {
     let key = layout.as_ptr() as usize;
     if let Some(cached) = layout_cache()
         .read()
@@ -99,11 +97,7 @@ fn python_rand_index(rng: &Bound<'_, PyAny>, upper: usize) -> PyResult<usize> {
     rng.call_method1("randrange", (upper,))?.extract()
 }
 
-fn python_randrange(
-    rng: &Bound<'_, PyAny>,
-    start: usize,
-    stop: usize,
-) -> PyResult<usize> {
+fn python_randrange(rng: &Bound<'_, PyAny>, start: usize, stop: usize) -> PyResult<usize> {
     rng.call_method1("randrange", (start, stop))?.extract()
 }
 


### PR DESCRIPTION
## Summary
- add `affix_bounds` to reuse word segmentation data and avoid cloning when collecting redaction candidates
- rebuild redaction replacements from live segments, use `String::repeat`, and cache the merge regex to eliminate repeated allocations
- run `cargo fmt`, updating a couple of Typogre helper signatures

## Testing
- `cargo test --manifest-path rust/zoo/Cargo.toml` *(fails: requires Python development libraries for linking)*

------
https://chatgpt.com/codex/tasks/task_e_68ea9099dbd8833290a8cc4c7bec5597