### PR TITLE
Optimize TypoOp sampling allocations

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -407,4 +407,5 @@ dependencies = [
  "pyo3",
  "pyo3-build-config",
  "regex",
+ "smallvec",
 ]

--- a/rust/zoo/Cargo.toml
+++ b/rust/zoo/Cargo.toml
@@ -13,6 +13,7 @@ pyo3 = { workspace = true }
 regex = { workspace = true }
 once_cell = { workspace = true }
 blake2 = { workspace = true }
+smallvec = "1"
 
 [package.metadata.maturin]
 module-name = "glitchlings._zoo_rust"

--- a/rust/zoo/src/glitch_ops.rs
+++ b/rust/zoo/src/glitch_ops.rs
@@ -1,6 +1,7 @@
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::PyErr;
 use regex::{Captures, Regex};
+use smallvec::SmallVec;
 use std::collections::HashMap;
 
 use crate::resources::{
@@ -756,18 +757,27 @@ impl TypoOp {
     }
 
     fn remove_space(rng: &mut dyn GlitchRng, chars: &mut Vec<char>) -> Result<(), GlitchOpError> {
-        let positions: Vec<usize> = chars
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, ch)| if *ch == ' ' { Some(idx) } else { None })
-            .collect();
-        if positions.is_empty() {
+        let mut count = 0usize;
+        for ch in chars.iter() {
+            if *ch == ' ' {
+                count += 1;
+            }
+        }
+        if count == 0 {
             return Ok(());
         }
-        let choice = rng.rand_index(positions.len())?;
-        let idx = positions[choice];
-        if idx < chars.len() {
-            chars.remove(idx);
+        let choice = rng.rand_index(count)?;
+        let mut seen = 0usize;
+        for (idx, ch) in chars.iter().enumerate() {
+            if *ch == ' ' {
+                if seen == choice {
+                    if idx < chars.len() {
+                        chars.remove(idx);
+                    }
+                    break;
+                }
+                seen += 1;
+            }
         }
         Ok(())
     }
@@ -784,19 +794,26 @@ impl TypoOp {
     }
 
     fn repeat_char(rng: &mut dyn GlitchRng, chars: &mut Vec<char>) -> Result<(), GlitchOpError> {
-        let positions: Vec<usize> = chars
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, ch)| if ch.is_whitespace() { None } else { Some(idx) })
-            .collect();
-        if positions.is_empty() {
+        let mut count = 0usize;
+        for ch in chars.iter() {
+            if !ch.is_whitespace() {
+                count += 1;
+            }
+        }
+        if count == 0 {
             return Ok(());
         }
-        let choice = rng.rand_index(positions.len())?;
-        let idx = positions[choice];
-        if idx < chars.len() {
-            let ch = chars[idx];
-            chars.insert(idx, ch);
+        let choice = rng.rand_index(count)?;
+        let mut seen = 0usize;
+        for idx in 0..chars.len() {
+            if !chars[idx].is_whitespace() {
+                if seen == choice {
+                    let ch = chars[idx];
+                    chars.insert(idx, ch);
+                    break;
+                }
+                seen += 1;
+            }
         }
         Ok(())
     }
@@ -857,13 +874,10 @@ impl GlitchOp for TypoOp {
         }
 
         const TOTAL_ACTIONS: usize = 8;
-        let mut actions: Vec<u8> = Vec::with_capacity(max_changes);
-        for _ in 0..max_changes {
-            let action_idx = rng.rand_index(TOTAL_ACTIONS)?;
-            actions.push(action_idx as u8);
-        }
+        let mut scratch = SmallVec::<[char; 4]>::new();
 
-        for action_idx in actions {
+        for _ in 0..max_changes {
+            let action_idx = rng.rand_index(TOTAL_ACTIONS)? as u8;
             match action_idx as usize {
                 0 | 1 | 2 | 3 => {
                     if let Some(idx) = Self::draw_eligible_index(rng, &chars, 16)? {
@@ -881,19 +895,21 @@ impl GlitchOp for TypoOp {
                             2 => {
                                 if idx < chars.len() {
                                     let ch = chars[idx];
-                                    let insertion = match self.neighbors_for_char(ch) {
+                                    scratch.clear();
+                                    match self.neighbors_for_char(ch) {
                                         Some(neighbors) if !neighbors.is_empty() => {
                                             let choice = rng.rand_index(neighbors.len())?;
-                                            neighbors[choice].clone()
+                                            scratch.extend(neighbors[choice].chars());
                                         }
                                         _ => {
                                             // Match Python fallback that still advances RNG state.
                                             rng.rand_index(1)?;
-                                            ch.to_string()
+                                            scratch.push(ch);
                                         }
-                                    };
-                                    let insertion_chars: Vec<char> = insertion.chars().collect();
-                                    chars.splice(idx..idx, insertion_chars);
+                                    }
+                                    if !scratch.is_empty() {
+                                        chars.splice(idx..idx, scratch.iter().copied());
+                                    }
                                 }
                             }
                             3 => {
@@ -903,9 +919,11 @@ impl GlitchOp for TypoOp {
                                             continue;
                                         }
                                         let choice = rng.rand_index(neighbors.len())?;
-                                        let replacement: Vec<char> =
-                                            neighbors[choice].chars().collect();
-                                        chars.splice(idx..idx + 1, replacement);
+                                        scratch.clear();
+                                        scratch.extend(neighbors[choice].chars());
+                                        if !scratch.is_empty() {
+                                            chars.splice(idx..idx + 1, scratch.iter().copied());
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
## Summary
- eliminate intermediate allocations in TypoOp by sampling actions on demand and reusing SmallVec buffers for keyboard neighbor mutations
- rework whitespace-targeting helpers to scan twice instead of building temporary position vectors
- add the smallvec dependency required for the new scratch buffers

## Testing
- cargo check -p zoo_rust

------
https://chatgpt.com/codex/tasks/task_e_68ea90c1eb1c83328440b51eeb88ee1d