### PR TITLE
Add PyTorch DLC integration for DataLoader glitching

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ print(gaggle(SAMPLE_TEXT))
 > Onҽ m‎ھ‎rning, wһen Gregor Samƽa woke from trouble𝐝 𝑑reams, he found himself transformed in his bed into a horrible vermin‎٠‎ He l   lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightlh domed and divided by arches ino stiff sections. The bedding was adly able to cover it and and seemed ready to slide off any  moment. His many legxs, pitifully thin compared with the size of the the rest of him, waved about helplessly ashe looked looked.
 
 Consult the [Glitchlings Usage Guide](docs/index.md)
-for end-to-end instructions spanning the Python API, CLI, HuggingFace and Prime Intellect
+for end-to-end instructions spanning the Python API, CLI, HuggingFace, PyTorch, and Prime Intellect
 integrations, and the autodetected Rust pipeline (enabled whenever the extension is present).
 
 ## Motivation

--- a/docs/index.md
+++ b/docs/index.md
@@ -121,6 +121,7 @@ Glitchlings slot neatly into existing pipelines:
 
 - **Direct invocation** – Instantiate a glitchling (or `Gaggle`) and call it on strings, iterables, or datasets. Keep the seed stable to reproduce every run.
 - **Dataset corruption** – After ``import glitchlings.dlc.huggingface`` registers the extension, call ``Dataset.glitch(...)`` (or a `Gaggle`'s `.corrupt_dataset`) to perturb a Hugging Face `datasets.Dataset` and return a corrupted copy for training or evaluation.
+- **PyTorch data loaders** – Import ``glitchlings.dlc.pytorch`` to patch ``torch.utils.data.DataLoader.glitch(...)``. The wrapper infers textual fields automatically or honours explicit column names/indices while leaving other batch data untouched.
 
 ### Command line interface
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ glitchlings = "glitchlings.main:main"
 hf = ["datasets>=4.0.0"]
 vectors = ["numpy>=1.24,<=2.0", "spacy>=3.7.2", "gensim>=4.3.2"]
 prime = ["verifiers>=0.1.3.post0", "jellyfish>=1.2.0"]
+torch = ["torch>=2.0.0"]
 dev = [
     "pytest>=8.0.0",
     "hypothesis>=6.140.0",

--- a/src/glitchlings/compat.py
+++ b/src/glitchlings/compat.py
@@ -92,11 +92,12 @@ verifiers = OptionalDependency("verifiers")
 jellyfish = OptionalDependency("jellyfish")
 jsonschema = OptionalDependency("jsonschema")
 nltk = OptionalDependency("nltk")
+torch = OptionalDependency("torch")
 
 
 def reset_optional_dependencies() -> None:
     """Clear cached optional dependency imports (used by tests)."""
-    for dependency in (datasets, verifiers, jellyfish, jsonschema, nltk):
+    for dependency in (datasets, verifiers, jellyfish, jsonschema, nltk, torch):
         dependency.reset()
 
 
@@ -118,6 +119,11 @@ def require_verifiers(message: str = "verifiers is not installed") -> ModuleType
 def require_jellyfish(message: str = "jellyfish is not installed") -> ModuleType:
     """Ensure the jellyfish dependency is present."""
     return jellyfish.require(message)
+
+
+def require_torch(message: str = "torch is not installed") -> ModuleType:
+    """Ensure the PyTorch dependency is present."""
+    return torch.require(message)
 
 
 def get_installed_extras(

--- a/src/glitchlings/dlc/__init__.py
+++ b/src/glitchlings/dlc/__init__.py
@@ -1,5 +1,6 @@
 """Optional DLC integrations for Glitchlings."""
 
 from .huggingface import install as install_huggingface
+from .pytorch import install as install_pytorch
 
-__all__ = ["install_huggingface"]
+__all__ = ["install_huggingface", "install_pytorch"]

--- a/src/glitchlings/dlc/pytorch.py
+++ b/src/glitchlings/dlc/pytorch.py
@@ -1,0 +1,219 @@
+"""Integration helpers for PyTorch data loaders."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator, Mapping, MutableMapping, Sequence
+from typing import Any, cast
+
+from ..compat import require_torch
+from ..compat import torch as _torch_dependency
+from ..util.adapters import coerce_gaggle
+from ..zoo import Gaggle, Glitchling
+from ..zoo.core import _is_transcript
+
+
+def _normalise_columns(columns: str | int | Sequence[str | int] | None) -> list[str | int] | None:
+    """Normalise a column specification into a list of keys or indices."""
+    if columns is None:
+        return None
+
+    if isinstance(columns, (str, int)):
+        return [columns]
+
+    normalised = list(columns)
+    if not normalised:
+        raise ValueError("At least one column must be specified")
+    return normalised
+
+
+def _is_textual_candidate(value: Any) -> bool:
+    """Return ``True`` when ``value`` looks like text that glitchlings can corrupt."""
+    if isinstance(value, str):
+        return True
+
+    if _is_transcript(value, allow_empty=False, require_all_content=True):
+        return True
+
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray, str)):
+        if not value:
+            return False
+        if all(isinstance(item, str) for item in value):
+            return True
+        if _is_transcript(list(value), allow_empty=False, require_all_content=True):
+            return True
+
+    return False
+
+
+def _corrupt_text(value: Any, gaggle: Gaggle) -> Any:
+    """Return ``value`` with glitchlings applied when possible."""
+    if isinstance(value, str):
+        return gaggle.corrupt(value)
+
+    if _is_transcript(value, allow_empty=True):
+        return gaggle.corrupt(value)
+
+    if isinstance(value, list) and value and all(isinstance(item, str) for item in value):
+        return [gaggle.corrupt(item) for item in value]
+
+    if isinstance(value, tuple) and value and all(isinstance(item, str) for item in value):
+        return tuple(gaggle.corrupt(item) for item in value)
+
+    return value
+
+
+def _apply_to_batch(batch: Any, targets: list[str | int] | None, gaggle: Gaggle) -> Any:
+    """Return ``batch`` with glitchlings applied to the specified ``targets``."""
+    if targets is None:
+        return _corrupt_text(batch, gaggle)
+
+    if isinstance(batch, Mapping):
+        if isinstance(batch, MutableMapping):
+            mutated = cast(MutableMapping[str, Any], batch.copy())
+        else:
+            mutated = cast(MutableMapping[str, Any], dict(batch))
+        for key in targets:
+            if not isinstance(key, str):
+                raise TypeError("Mapping batches require string column names")
+            if key not in mutated:
+                raise ValueError(f"Column '{key}' not found in DataLoader batch")
+            mutated[key] = _corrupt_text(mutated[key], gaggle)
+        return mutated
+
+    if isinstance(batch, Sequence) and not isinstance(batch, (bytes, bytearray, str)):
+        mutated_sequence = list(batch)
+        for index in targets:
+            if not isinstance(index, int):
+                raise TypeError("Sequence batches require integer column indices")
+            try:
+                mutated_sequence[index] = _corrupt_text(mutated_sequence[index], gaggle)
+            except IndexError as exc:  # pragma: no cover - defensive
+                raise IndexError("Column index out of range for DataLoader batch") from exc
+        if isinstance(batch, tuple):
+            return tuple(mutated_sequence)
+        return mutated_sequence
+
+    raise TypeError("Unsupported DataLoader batch type for glitching")
+
+
+def _infer_targets(batch: Any) -> list[str | int] | None:
+    """Infer which fields should be glitched from a representative ``batch``."""
+    if isinstance(batch, Mapping):
+        inferred = [key for key, value in batch.items() if _is_textual_candidate(value)]
+        if inferred:
+            return inferred
+        raise ValueError("Unable to infer which mapping columns contain text")
+
+    if isinstance(batch, Sequence) and not isinstance(batch, (bytes, bytearray, str)):
+        inferred_indices = [idx for idx, value in enumerate(batch) if _is_textual_candidate(value)]
+        if inferred_indices:
+            return inferred_indices
+        raise ValueError("Unable to infer which sequence indices contain text")
+
+    if _is_textual_candidate(batch):
+        return None
+
+    raise TypeError("Unsupported DataLoader batch type for glitching")
+
+
+class _GlitchedDataLoader(Iterable[Any]):
+    """Wrapper that applies glitchlings lazily to each batch from a data loader."""
+
+    def __init__(
+        self,
+        dataloader: Any,
+        gaggle: Gaggle,
+        *,
+        columns: list[str | int] | None,
+    ) -> None:
+        self._dataloader = dataloader
+        self._gaggle = gaggle
+        self._explicit_columns = columns
+        self._inferred_columns: list[str | int] | None | _Sentinel = _UNINITIALISED
+
+    def __iter__(self) -> Iterator[Any]:
+        # Reset all glitchling RNGs before each fresh pass for determinism.
+        self._gaggle.sort_glitchlings()
+        for batch in self._dataloader:
+            targets = self._resolve_columns(batch)
+            yield _apply_to_batch(batch, targets, self._gaggle)
+
+    def __len__(self) -> int:
+        return len(self._dataloader)
+
+    def __getattr__(self, attribute: str) -> Any:
+        return getattr(self._dataloader, attribute)
+
+    def _resolve_columns(self, batch: Any) -> list[str | int] | None:
+        if self._explicit_columns is not None:
+            return self._explicit_columns
+
+        if self._inferred_columns is _UNINITIALISED:
+            self._inferred_columns = _infer_targets(batch)
+
+        return cast(list[str | int] | None, self._inferred_columns)
+
+
+class _Sentinel:
+    """Sentinel type for deferred column inference."""
+
+
+_UNINITIALISED = _Sentinel()
+
+
+def _ensure_dataloader_class() -> type[Any]:
+    """Return :class:`torch.utils.data.DataLoader` patched with ``.glitch``."""
+    torch_module = require_torch("torch is not installed; install glitchlings[torch]")
+    utils_module = getattr(torch_module, "utils", None)
+    data_module = getattr(utils_module, "data", None) if utils_module is not None else None
+    dataloader_cls = getattr(data_module, "DataLoader", None)
+    if dataloader_cls is None:  # pragma: no cover - defensive
+        raise ModuleNotFoundError("torch.utils.data.DataLoader is not available")
+
+    if getattr(dataloader_cls, "glitch", None) is None:
+
+        def glitch(
+            self: Any,
+            glitchlings: Iterable[str | Glitchling] | Glitchling | str | Gaggle,
+            *,
+            columns: str | int | Sequence[str | int] | None = None,
+            seed: int = 151,
+        ) -> _GlitchedDataLoader:
+            """Return a lazily glitched view of the loader's batches."""
+            gaggle = coerce_gaggle(glitchlings, seed=seed)
+            normalised = _normalise_columns(columns)
+            return _GlitchedDataLoader(self, gaggle, columns=normalised)
+
+        setattr(dataloader_cls, "glitch", glitch)
+
+    return cast(type[Any], dataloader_cls)
+
+
+def _optional_dataloader_class() -> type[Any] | None:
+    """Return the PyTorch :class:`~torch.utils.data.DataLoader` when importable."""
+    torch_module = _torch_dependency.get()
+    if torch_module is None:
+        return None
+
+    utils_module = getattr(torch_module, "utils", None)
+    data_module = getattr(utils_module, "data", None) if utils_module is not None else None
+    dataloader_cls = getattr(data_module, "DataLoader", None)
+    if dataloader_cls is None:
+        return None
+    return cast(type[Any], dataloader_cls)
+
+
+def install() -> None:
+    """Monkeypatch PyTorch's :class:`~torch.utils.data.DataLoader` with ``.glitch``."""
+    _ensure_dataloader_class()
+
+
+DataLoader: type[Any] | None
+_DataLoaderAlias = _optional_dataloader_class()
+if _DataLoaderAlias is not None:
+    DataLoader = _ensure_dataloader_class()
+else:  # pragma: no cover - torch is an optional dependency
+    DataLoader = None
+
+
+__all__ = ["DataLoader", "install"]

--- a/tests/dlc/test_pytorch_dlc.py
+++ b/tests/dlc/test_pytorch_dlc.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from collections.abc import Iterable
+from random import Random
+from typing import Any
+
+import pytest
+
+from glitchlings.compat import reset_optional_dependencies
+from glitchlings.zoo import Gaggle, Glitchling
+from glitchlings.zoo.core import AttackWave
+
+
+def append_rng_token(text: str, *, rng: Random) -> str:
+    """Append a deterministic RNG token to the supplied text."""
+    return f"{text}-{rng.randint(0, 999)}"
+
+
+@pytest.fixture(autouse=True)
+def torch_stub() -> Iterable[type[Any]]:
+    """Install a lightweight torch stub that exposes ``DataLoader``."""
+    preserved = {name: sys.modules.get(name) for name in ("torch", "torch.utils", "torch.utils.data")}
+    for name in preserved:
+        sys.modules.pop(name, None)
+
+    torch_module = types.ModuleType("torch")
+    utils_module = types.ModuleType("torch.utils")
+    data_module = types.ModuleType("torch.utils.data")
+
+    class DummyDataLoader:
+        def __init__(self, dataset: list[Any]) -> None:
+            self.dataset = dataset
+            self.batch_size = None
+
+        def __iter__(self) -> Iterable[Any]:
+            return iter(self.dataset)
+
+        def __len__(self) -> int:
+            return len(self.dataset)
+
+    data_module.DataLoader = DummyDataLoader
+    utils_module.data = data_module
+    torch_module.utils = utils_module
+
+    sys.modules["torch"] = torch_module
+    sys.modules["torch.utils"] = utils_module
+    sys.modules["torch.utils.data"] = data_module
+
+    reset_optional_dependencies()
+
+    yield DummyDataLoader
+
+    for name, module in preserved.items():
+        if module is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = module
+    reset_optional_dependencies()
+
+
+@pytest.fixture()
+def pytorch_dlc() -> types.ModuleType:
+    """Reload the PyTorch DLC module against the stub."""
+    sys.modules.pop("glitchlings.dlc.pytorch", None)
+    module = importlib.import_module("glitchlings.dlc.pytorch")
+    module.install()
+    return module
+
+
+def test_install_is_idempotent(pytorch_dlc: types.ModuleType) -> None:
+    loader_cls = pytorch_dlc.DataLoader
+    assert loader_cls is not None
+    initial_method = getattr(loader_cls, "glitch", None)
+
+    pytorch_dlc.install()
+    assert getattr(loader_cls, "glitch") is initial_method
+
+
+def test_glitch_corrupts_named_columns(pytorch_dlc: types.ModuleType) -> None:
+    loader_cls = pytorch_dlc.DataLoader
+    assert loader_cls is not None
+
+    dataset = [{"text": ["alpha", "beta"], "label": [0, 1]}]
+    loader = loader_cls(dataset)
+
+    glitchling = Glitchling("rngster", append_rng_token, AttackWave.SENTENCE, seed=404)
+    glitched_loader = loader.glitch(glitchling, columns="text", seed=21)
+
+    batches = list(glitched_loader)
+    assert len(batches) == 1
+    batch = batches[0]
+    assert batch["label"] == [0, 1]
+    assert batch["text"][0].startswith("alpha-")
+    assert dataset[0]["text"][0] == "alpha"
+
+    rerun = list(glitched_loader)
+    assert rerun == batches
+
+
+def test_glitch_infers_textual_columns(pytorch_dlc: types.ModuleType) -> None:
+    loader_cls = pytorch_dlc.DataLoader
+    assert loader_cls is not None
+
+    dataset = [{"text": "alpha", "label": 1}]
+    loader = loader_cls(dataset)
+
+    glitchling = Glitchling("rngster", append_rng_token, AttackWave.SENTENCE, seed=123)
+    glitched_loader = loader.glitch([glitchling], seed=99)
+
+    batches = list(glitched_loader)
+    assert batches[0]["label"] == 1
+    assert batches[0]["text"].startswith("alpha-")
+    assert list(glitched_loader) == batches
+
+
+def test_glitch_accepts_sequence_indices(pytorch_dlc: types.ModuleType) -> None:
+    loader_cls = pytorch_dlc.DataLoader
+    assert loader_cls is not None
+
+    dataset = [("alpha", 1), ("beta", 0)]
+    loader = loader_cls(dataset)
+
+    gaggle = Gaggle(
+        [Glitchling("rngster", append_rng_token, AttackWave.SENTENCE, seed=77)],
+        seed=11,
+    )
+    glitched_loader = loader.glitch(gaggle, columns=(0,))
+
+    batches = list(glitched_loader)
+    assert batches[0][0].startswith("alpha-")
+    assert batches[0][1] == 1
+
+
+def test_glitch_rejects_empty_column_sequence(pytorch_dlc: types.ModuleType) -> None:
+    loader_cls = pytorch_dlc.DataLoader
+    assert loader_cls is not None
+
+    dataset = [{"text": "alpha"}]
+    loader = loader_cls(dataset)
+
+    glitchling = Glitchling("rngster", append_rng_token, AttackWave.SENTENCE, seed=55)
+
+    with pytest.raises(ValueError, match="At least one column"):
+        loader.glitch(glitchling, columns=())


### PR DESCRIPTION
## Summary
- add an optional `glitchlings.dlc.pytorch` module that patches `torch.utils.data.DataLoader` with a `glitch` helper
- expose the PyTorch DLC installer alongside a new `torch` extra and optional dependency wiring
- document the integration and cover the wrapper with dedicated tests

## Testing
- pytest tests/dlc/test_pytorch_dlc.py

------
https://chatgpt.com/codex/tasks/task_e_68ec87438c348332b5fbfc432a98488b