### PR TITLE
Broaden formatting hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,19 +3,15 @@ repos:
     rev: 24.8.0
     hooks:
       - id: black
-        args: [src/glitchlings/dlc, src/glitchlings/util/adapters.py]
-        pass_filenames: false
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:
       - id: isort
-        args: [src/glitchlings/dlc, src/glitchlings/util/adapters.py]
-        pass_filenames: false
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.6.7
     hooks:
       - id: ruff
-        args: [--fix, src/glitchlings/dlc, src/glitchlings/util/adapters.py]
+        args: [--fix]
   - repo: local
     hooks:
       - id: mypy


### PR DESCRIPTION
## Summary
- allow black and isort pre-commit hooks to run on the default staged files
- keep ruff autofix while letting it lint the full staged set

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed82f2c4f0833292ed82f60485839e