### PR TITLE
Add all extra for tooling and tweak CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e .[dev]
+          python -m pip install -e .[all]
       - name: Ruff
-        run: ruff check --fix src
+        run: ruff check src
       - name: Black
         run: black src
       - name: Mypy
         run: python -m mypy src
+      - name: Pytest
+        run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,23 @@ Changelog = "https://github.com/osoleve/glitchlings/releases"
 glitchlings = "glitchlings.main:main"
 
 [project.optional-dependencies]
+all = [
+    "black>=24.4.0",
+    "hypothesis>=6.140.0",
+    "interrogate>=1.5.0",
+    "jellyfish>=1.2.0",
+    "isort>=5.13.0",
+    "mkdocs>=1.6.0",
+    "mkdocs-material>=9.5.0",
+    "mkdocstrings[python]>=0.24.0",
+    "mkdocstrings-python>=1.10.0",
+    "mypy>=1.8.0",
+    "numpy>=1.24,<=2.0",
+    "pre-commit>=3.8.0",
+    "pytest>=8.0.0",
+    "ruff>=0.6.0",
+    "verifiers>=0.1.3.post0",
+]
 hf = ["datasets>=4.0.0"]
 lightning = ["pytorch_lightning>=2.0.0"]
 vectors = ["numpy>=1.24,<=2.0", "spacy>=3.7.2", "gensim>=4.3.2"]


### PR DESCRIPTION
## Summary
- add an [all] optional dependency extra that combines the development and prime requirements
- update the quality gates workflow to install the new target and run ruff without autofix

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ed82c9ce28833286f839933c7bdf13