### PR TITLE
Update Rust code to use PyO3 0.23 API

### DIFF
--- a/rust/zoo/src/lib.rs
+++ b/rust/zoo/src/lib.rs
@@ -54,7 +54,7 @@ impl<'py> GlitchRng for PythonRngAdapter<'py> {
         k: usize,
     ) -> Result<Vec<usize>, glitch_ops::GlitchOpError> {
         let py = self.rng.py();
-        let population_list = PyList::new_bound(py, 0..population).unbind();
+        let population_list = PyList::new(py, 0..population).unbind();
         self.rng
             .call_method1("sample", (population_list, k))
             .map_err(glitch_ops::GlitchOpError::from_pyerr)?
@@ -71,8 +71,8 @@ struct PyGlitchDescriptor {
 }
 
 impl<'py> FromPyObject<'py> for PyGlitchDescriptor {
-    fn extract(obj: &'py PyAny) -> PyResult<Self> {
-        let dict: &PyDict = obj.downcast()?;
+    fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
+        let dict = obj.downcast::<PyDict>()?;
         let name = dict
             .get_item("name")?
             .ok_or_else(|| PyValueError::new_err("descriptor missing 'name' field"))?
@@ -100,7 +100,7 @@ fn layout_vec_cache() -> &'static RwLock<LayoutVecCache> {
     CACHE.get_or_init(|| RwLock::new(HashMap::new()))
 }
 
-fn cached_layout_vec(layout_dict: &PyDict) -> PyResult<Arc<Vec<(String, Vec<String>)>>> {
+fn cached_layout_vec(layout_dict: &Bound<'_, PyDict>) -> PyResult<Arc<Vec<(String, Vec<String>)>>> {
     let key = layout_dict.as_ptr() as usize;
     if let Some(cached) = layout_vec_cache()
         .read()
@@ -130,7 +130,7 @@ struct PyGagglePlanInput {
 }
 
 impl<'py> FromPyObject<'py> for PyGagglePlanInput {
-    fn extract(obj: &'py PyAny) -> PyResult<Self> {
+    fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
         if let Ok(dict) = obj.downcast::<PyDict>() {
             let name: String = dict
                 .get_item("name")?
@@ -197,8 +197,8 @@ enum PyGlitchOperation {
 }
 
 impl<'py> FromPyObject<'py> for PyGlitchOperation {
-    fn extract(obj: &'py PyAny) -> PyResult<Self> {
-        let dict: &PyDict = obj.downcast()?;
+    fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
+        let dict = obj.downcast::<PyDict>()?;
         let op_type: String = dict
             .get_item("type")?
             .ok_or_else(|| PyValueError::new_err("operation missing 'type' field"))?
@@ -293,7 +293,7 @@ impl<'py> FromPyObject<'py> for PyGlitchOperation {
                 let layout_obj = dict.get_item("layout")?.ok_or_else(|| {
                     PyValueError::new_err("typo operation missing \'layout\' field")
                 })?;
-                let layout_dict: &PyDict = layout_obj.downcast()?;
+                let layout_dict = layout_obj.downcast::<PyDict>()?;
                 let layout = cached_layout_vec(layout_dict)?;
                 Ok(PyGlitchOperation::Typo { rate, layout })
             }

--- a/rust/zoo/src/zeedub.rs
+++ b/rust/zoo/src/zeedub.rs
@@ -65,7 +65,7 @@ pub(crate) fn inject_zero_widths(
     }
 
     let py = rng.py();
-    let positions_list = PyList::new_bound(py, &positions);
+    let positions_list = PyList::new(py, &positions);
     let sample_obj = rng.call_method1("sample", (&positions_list, count))?;
     let mut chosen: Vec<usize> = sample_obj.extract()?;
     chosen.sort_unstable();


### PR DESCRIPTION
Migrate from PyO3 0.21 API to PyO3 0.23's new Bound<T> API:

- Change FromPyObject::extract() to FromPyObject::extract_bound()
- Update method signatures to use &Bound<'py, PyAny> instead of &'py PyAny
- Update downcast() calls to use explicit type parameters
- Update cached_layout_vec() to accept &Bound<PyDict>
- Replace deprecated PyList::new_bound() with PyList::new()

These changes are required for compatibility with PyO3 0.23, which introduced breaking changes to the Python object handling API by moving from raw references to the Bound<T> smart pointer type.

Fixes compilation errors:
- E0407: method `extract` is not a member of trait `FromPyObject`
- E0046: missing `extract_bound` in FromPyObject implementation
- E0599: no method named `downcast` found for &PyAny
- Deprecation warnings for PyList::new_bound

🤖 Generated with [Claude Code](https://claude.com/claude-code)