### PR TITLE
Fix PyList::new() Result handling for PyO3 0.23

### DIFF
--- a/rust/zoo/src/lib.rs
+++ b/rust/zoo/src/lib.rs
@@ -54,7 +54,9 @@ impl<'py> GlitchRng for PythonRngAdapter<'py> {
         k: usize,
     ) -> Result<Vec<usize>, glitch_ops::GlitchOpError> {
         let py = self.rng.py();
-        let population_list = PyList::new(py, 0..population).unbind();
+        let population_list = PyList::new(py, 0..population)
+            .map_err(glitch_ops::GlitchOpError::from_pyerr)?
+            .unbind();
         self.rng
             .call_method1("sample", (population_list, k))
             .map_err(glitch_ops::GlitchOpError::from_pyerr)?

--- a/rust/zoo/src/zeedub.rs
+++ b/rust/zoo/src/zeedub.rs
@@ -65,7 +65,7 @@ pub(crate) fn inject_zero_widths(
     }
 
     let py = rng.py();
-    let positions_list = PyList::new(py, &positions);
+    let positions_list = PyList::new(py, &positions)?;
     let sample_obj = rng.call_method1("sample", (&positions_list, count))?;
     let mut chosen: Vec<usize> = sample_obj.extract()?;
     chosen.sort_unstable();


### PR DESCRIPTION
PyList::new() now returns a Result in PyO3 0.23, requiring explicit error handling with the ? operator before accessing the Bound value.

Changes:
- lib.rs: Handle Result from PyList::new() with map_err before unbind()
- zeedub.rs: Add ? operator to unwrap PyList::new() Result

Fixes compilation errors:
- E0599: no method named `unbind` found for enum `Result`
- E0277: `&Result<Bound<PyList>, PyErr>` cannot be converted to Python object

🤖 Generated with [Claude Code](https://claude.com/claude-code)