### PR TITLE
Reduce technical debt: standardize naming and extract constants

### DIFF
--- a/src/glitchlings/dlc/_shared.py
+++ b/src/glitchlings/dlc/_shared.py
@@ -67,10 +67,10 @@ def resolve_columns(dataset: Any, columns: Sequence[str] | None) -> list[str]:
     raise ValueError("Unable to determine which dataset columns to corrupt.")
 
 
-def normalise_column_spec(
+def normalize_column_spec(
     columns: str | int | Sequence[str | int] | None,
 ) -> list[str | int] | None:
-    """Normalise a column specification into a list of keys or indices.
+    """Normalize a column specification into a list of keys or indices.
 
     Args:
         columns: Column specification as a single value, sequence of values, or None.
@@ -87,10 +87,10 @@ def normalise_column_spec(
     if isinstance(columns, (str, int)):
         return [columns]
 
-    normalised = list(columns)
-    if not normalised:
+    normalized = list(columns)
+    if not normalized:
         raise ValueError("At least one column must be specified")
-    return normalised
+    return normalized
 
 
 def is_textual_candidate(value: Any) -> bool:
@@ -147,7 +147,7 @@ def corrupt_text_value(value: Any, gaggle: Gaggle) -> Any:
 __all__ = [
     "corrupt_text_value",
     "is_textual_candidate",
-    "normalise_column_spec",
+    "normalize_column_spec",
     "resolve_columns",
     "resolve_environment",
 ]

--- a/src/glitchlings/dlc/huggingface.py
+++ b/src/glitchlings/dlc/huggingface.py
@@ -10,15 +10,15 @@ from ..util.adapters import coerce_gaggle
 from ..zoo import Gaggle, Glitchling
 
 
-def _normalise_columns(column: str | Sequence[str]) -> list[str]:
-    """Normalise a column specification to a list."""
+def _normalize_columns(column: str | Sequence[str]) -> list[str]:
+    """Normalize a column specification to a list."""
     if isinstance(column, str):
         return [column]
 
-    normalised = list(column)
-    if not normalised:
+    normalized = list(column)
+    if not normalized:
         raise ValueError("At least one column must be specified")
-    return normalised
+    return normalized
 
 
 def _glitch_dataset(
@@ -29,7 +29,7 @@ def _glitch_dataset(
     seed: int = 151,
 ) -> Any:
     """Apply glitchlings to the provided dataset columns."""
-    columns = _normalise_columns(column)
+    columns = _normalize_columns(column)
     gaggle = coerce_gaggle(glitchlings, seed=seed)
     return gaggle.corrupt_dataset(dataset, columns)
 

--- a/src/glitchlings/dlc/prime.py
+++ b/src/glitchlings/dlc/prime.py
@@ -117,7 +117,7 @@ def _as_gaggle(
 
 
 def _extract_completion_text(completion: Any) -> str:
-    """Normalise a completion payload into a plain string."""
+    """Normalize a completion payload into a plain string."""
     if isinstance(completion, str):
         return completion
 

--- a/src/glitchlings/dlc/pytorch.py
+++ b/src/glitchlings/dlc/pytorch.py
@@ -9,7 +9,7 @@ from ..compat import get_torch_dataloader, require_torch
 from ..compat import torch as _torch_dependency
 from ..util.adapters import coerce_gaggle
 from ..zoo import Gaggle, Glitchling
-from ._shared import corrupt_text_value, is_textual_candidate, normalise_column_spec
+from ._shared import corrupt_text_value, is_textual_candidate, normalize_column_spec
 
 
 def _apply_to_batch(batch: Any, targets: list[str | int] | None, gaggle: Gaggle) -> Any:
@@ -134,8 +134,8 @@ def _ensure_dataloader_class() -> type[Any]:
         ) -> _GlitchedDataLoader:
             """Return a lazily glitched view of the loader's batches."""
             gaggle = coerce_gaggle(glitchlings, seed=seed)
-            normalised = normalise_column_spec(columns)
-            return _GlitchedDataLoader(self, gaggle, columns=normalised)
+            normalized = normalize_column_spec(columns)
+            return _GlitchedDataLoader(self, gaggle, columns=normalized)
 
         setattr(dataloader_cls, "glitch", glitch)
 

--- a/src/glitchlings/dlc/pytorch_lightning.py
+++ b/src/glitchlings/dlc/pytorch_lightning.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 from ..compat import get_pytorch_lightning_datamodule, require_pytorch_lightning
 from ..util.adapters import coerce_gaggle
 from ..zoo import Gaggle, Glitchling
-from ._shared import corrupt_text_value, normalise_column_spec
+from ._shared import corrupt_text_value, normalize_column_spec
 
 
 def _glitch_batch(batch: Any, columns: list[str], gaggle: Gaggle) -> Any:
@@ -89,7 +89,7 @@ def _glitch_datamodule(
 ) -> Any:
     """Return a proxy that applies glitchlings to batches from the datamodule."""
 
-    columns = normalise_column_spec(column)
+    columns = normalize_column_spec(column)
     if columns is None:  # pragma: no cover - defensive
         raise ValueError("At least one column must be specified")
     # Lightning datamodules only support string column names (mapping keys)

--- a/src/glitchlings/lexicon/_cache.py
+++ b/src/glitchlings/lexicon/_cache.py
@@ -19,7 +19,7 @@ class CacheSnapshot:
     checksum: str | None = None
 
 
-def _normalise_entries(payload: Mapping[str, object]) -> CacheEntries:
+def _normalize_entries(payload: Mapping[str, object]) -> CacheEntries:
     """Convert raw cache payloads into canonical mapping form."""
     entries: CacheEntries = {}
     for key, values in payload.items():
@@ -75,7 +75,7 @@ def load_cache(path: Path) -> CacheSnapshot:
     else:
         entries_payload = payload  # legacy format without metadata
 
-    entries = _normalise_entries(entries_payload)
+    entries = _normalize_entries(entries_payload)
     if checksum is not None:
         expected = compute_checksum(entries)
         if checksum != expected:

--- a/src/glitchlings/lexicon/vector.py
+++ b/src/glitchlings/lexicon/vector.py
@@ -16,6 +16,9 @@ from ._cache import CacheSnapshot
 from ._cache import load_cache as _load_cache_file
 from ._cache import write_cache as _write_cache_file
 
+# Minimum number of neighbors to consider for similarity queries
+MIN_NEIGHBORS = 1
+
 
 def _cosine_similarity(vector_a: Sequence[float], vector_b: Sequence[float]) -> float:
     """Return the cosine similarity between two dense vectors."""
@@ -304,7 +307,7 @@ class VectorLexicon(LexiconBackend):
         """Initialise the lexicon with an embedding ``source`` and optional cache."""
         super().__init__(seed=seed)
         self._adapter = _resolve_source(source)
-        self._max_neighbors = max(1, max_neighbors)
+        self._max_neighbors = max(MIN_NEIGHBORS, max_neighbors)
         self._min_similarity = min_similarity
         self._cache: MutableMapping[str, list[str]] = {}
         self._cache_path: Path | None
@@ -371,7 +374,7 @@ class VectorLexicon(LexiconBackend):
         if cache_key in self._cache:
             return self._cache[cache_key]
 
-        neighbor_limit = self._max_neighbors if limit is None else max(1, limit)
+        neighbor_limit = self._max_neighbors if limit is None else max(MIN_NEIGHBORS, limit)
         neighbors = self._fetch_neighbors(
             original=original, normalized=normalized, limit=neighbor_limit
         )

--- a/tests/dlc/test_huggingface_dlc.py
+++ b/tests/dlc/test_huggingface_dlc.py
@@ -6,7 +6,7 @@ from random import Random
 import pytest
 
 from glitchlings.dlc import huggingface as hf_dlc
-from glitchlings.dlc.huggingface import _normalise_columns
+from glitchlings.dlc.huggingface import _normalize_columns
 from glitchlings.zoo.core import AttackWave, Gaggle, Glitchling
 
 datasets = pytest.importorskip("datasets")
@@ -24,9 +24,9 @@ def ensure_glitch_installed() -> Iterable[None]:
     yield
 
 
-def test_normalise_columns_rejects_empty_sequence() -> None:
+def test_normalize_columns_rejects_empty_sequence() -> None:
     with pytest.raises(ValueError, match="At least one column"):
-        _normalise_columns([])
+        _normalize_columns([])
 
 
 def test_install_is_idempotent() -> None:


### PR DESCRIPTION
Quick wins implemented:

1. Standardize spelling to American English
   - Renamed normalise_column_spec -> normalize_column_spec in dlc/_shared.py
   - Renamed _normalise_columns -> _normalize_columns in dlc/huggingface.py
   - Renamed _normalise_entries -> _normalize_entries in lexicon/_cache.py
   - Updated all imports and usages across dlc modules
   - Updated test file to match new naming

2. Extract magic numbers to named constants
   - Added MIN_NEIGHBORS constant in lexicon/vector.py
   - Replaced hardcoded `1` with MIN_NEIGHBORS in vector lexicon

These changes improve code consistency and maintainability without altering functionality. All core and lexicon tests pass (109 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)