### PR TITLE
Add hash-based asset integrity checks

### DIFF
--- a/docs/technical_debt.md
+++ b/docs/technical_debt.md
@@ -6,16 +6,18 @@
 - Added integrity checks in the pytest suite to guarantee staged Rust assets stay synchronised with the canonical Python sources and to catch regressions when legacy locations linger.
 - Streamlined the Hokey stretchability loader in Python to rely on the shared asset helpers, removing ad-hoc file access logic and normalising data ingestion across pipelines.
 - Tightened the Rust build process to stage assets exclusively from the canonical shared directory, preventing drift from deprecated resource paths.
+- Introduced a shared `load_json` helper in the asset module and migrated Apostrofae and the Hokey stretchability pipeline to use it, eliminating bespoke JSON parsing paths in the Python codebase.
+- Added a `python -m glitchlings.dev.sync_assets` helper plus a pytest guard to keep the vendored Rust asset bundle aligned with the canonical sources and surface divergence during CI runs.
+- Introduced cryptographic hash checks in the asset integrity tests so staged resources surface corruption or partial updates immediately.
 
 ## Observations
 
 - Maintaining parity between Python package data and the Rust crate still requires a vendored copy under `rust/zoo/assets/` for release builds; automated synchronisation would reduce the risk of stale files when packaging outside the monorepo.
-- Several legacy helpers in `glitchlings.util` still contain bespoke JSON loading code that predates the shared asset module and may benefit from consolidation.
+- Ancillary tooling such as cache builders still dip into JSON files directly; migrating them onto the shared helpers will fully retire bespoke loaders.
 - Asset integrity tests currently focus on text resources; binary assets (if introduced later) will need additional coverage to ensure checksums remain aligned.
 
 ## Next Steps
 
-1. Introduce a lightweight sync command (e.g., `python -m glitchlings.dev.sync_assets`) that updates vendored Rust assets from the canonical directory and integrates with CI to flag divergence before publishing.
-2. Audit remaining modules in `glitchlings.util` and `glitchlings.zoo` for filesystem access patterns and migrate them onto the shared loader abstractions where possible.
-3. Expand the asset integrity tests to compute cryptographic hashes for each staged resource, giving us a quick way to detect silent corruption or partial updates.
-4. Document the shared asset workflow in the contributor guide so future changes follow the canonical structure by default.
+1. Continue auditing modules in `glitchlings.util` and `glitchlings.zoo` (along with ancillary tooling like cache builders) to ensure every bundled resource goes through the asset helpers, expanding the new JSON loader to cover any remaining bespoke file access.
+2. Document the shared asset workflow in the contributor guide so future changes follow the canonical structure by default.
+3. Generate an asset manifest (e.g., the new digests) during release packaging so downstream consumers can verify bundled resources without running the test suite.

--- a/src/glitchlings/dev/__init__.py
+++ b/src/glitchlings/dev/__init__.py
@@ -1,0 +1,5 @@
+"""Developer-facing utilities for maintaining the Glitchlings repository."""
+
+from .sync_assets import sync_assets
+
+__all__ = ["sync_assets"]

--- a/src/glitchlings/dev/sync_assets.py
+++ b/src/glitchlings/dev/sync_assets.py
@@ -1,0 +1,146 @@
+"""Synchronise canonical glitchling assets with the vendored Rust copies."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+from typing import Iterable, Sequence
+
+RUST_VENDORED_ASSETS: frozenset[str] = frozenset({
+    "hokey_assets.json",
+    "ocr_confusions.tsv",
+})
+
+
+def _project_root(default: Path | None = None) -> Path:
+    if default is not None:
+        return default
+    return Path(__file__).resolve().parents[3]
+
+
+def _canonical_asset_dir(project_root: Path) -> Path:
+    canonical = project_root / "src" / "glitchlings" / "zoo" / "assets"
+    if not canonical.is_dir():
+        raise RuntimeError(
+            "expected canonical assets under 'src/glitchlings/zoo/assets'; "
+            "run this command from the repository root"
+        )
+    return canonical
+
+
+def _rust_asset_dir(project_root: Path) -> Path:
+    return project_root / "rust" / "zoo" / "assets"
+
+
+def _iter_extraneous_assets(rust_dir: Path) -> Iterable[Path]:
+    if not rust_dir.exists():
+        return ()
+    for path in rust_dir.iterdir():
+        if path.is_file() and path.name not in RUST_VENDORED_ASSETS:
+            yield path
+
+
+def sync_assets(
+    project_root: Path | None = None,
+    *,
+    check: bool = False,
+    quiet: bool = False,
+) -> bool:
+    """Synchronise the vendored Rust asset copies with the canonical sources."""
+
+    root = _project_root(project_root)
+    canonical_dir = _canonical_asset_dir(root)
+    rust_dir = _rust_asset_dir(root)
+
+    missing_sources = [name for name in RUST_VENDORED_ASSETS if not (canonical_dir / name).is_file()]
+    if missing_sources:
+        missing_list = ", ".join(sorted(missing_sources))
+        raise RuntimeError(f"missing canonical assets: {missing_list}")
+
+    extraneous = list(_iter_extraneous_assets(rust_dir))
+
+    mismatched: list[tuple[str, str]] = []
+    for name in sorted(RUST_VENDORED_ASSETS):
+        source = canonical_dir / name
+        target = rust_dir / name
+        if not target.exists():
+            mismatched.append((name, "missing"))
+            continue
+        if source.read_bytes() != target.read_bytes():
+            mismatched.append((name, "outdated"))
+
+    if check:
+        if mismatched or extraneous:
+            if not quiet:
+                for name, reason in mismatched:
+                    target = rust_dir / name
+                    print(
+                        f"{target.relative_to(root)} is {reason}; run sync_assets to refresh it",
+                        file=sys.stderr,
+                    )
+                for extra in extraneous:
+                    print(
+                        f"unexpected vendored asset {extra.relative_to(root)}; run sync_assets to prune it",
+                        file=sys.stderr,
+                    )
+            return False
+        if not quiet:
+            print("Rust asset bundle is up to date.")
+        return True
+
+    rust_dir.mkdir(parents=True, exist_ok=True)
+
+    for name, reason in mismatched:
+        source = canonical_dir / name
+        target = rust_dir / name
+        shutil.copy2(source, target)
+        if not quiet:
+            verb = "Copied" if reason == "missing" else "Updated"
+            print(
+                f"{verb} {source.relative_to(root)} -> {target.relative_to(root)}",
+            )
+
+    for extra in extraneous:
+        extra.unlink()
+        if not quiet:
+            print(f"Removed extraneous vendored asset {extra.relative_to(root)}")
+
+    if not mismatched and not extraneous and not quiet:
+        print("Rust asset bundle already aligned with canonical copies.")
+
+    return True
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Synchronise canonical glitchling assets with the vendored Rust copies.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="exit with a non-zero status when vendored assets diverge",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="suppress status output",
+    )
+    parser.add_argument(
+        "--project-root",
+        type=Path,
+        help="override the detected project root (useful for testing)",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    ok = sync_assets(project_root=args.project_root, check=args.check, quiet=args.quiet)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/src/glitchlings/util/stretchability.py
+++ b/src/glitchlings/util/stretchability.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-import json
 import re
 from dataclasses import dataclass
-from typing import Any, Protocol, Sequence, TypedDict, cast
+from typing import Protocol, Sequence, TypedDict, cast
 
 from glitchlings.zoo import assets
 
@@ -33,8 +32,7 @@ class RandomLike(Protocol):
 
 # Lexical prior probabilities and pragmatic lexica shared with the Rust fast path.
 def _load_assets() -> HokeyAssets:
-    with assets.open_text("hokey_assets.json") as payload:
-        data: Any = json.load(payload)
+    data = assets.load_json("hokey_assets.json")
     return cast(HokeyAssets, data)
 
 

--- a/src/glitchlings/zoo/apostrofae.py
+++ b/src/glitchlings/zoo/apostrofae.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-import json
 import random
 from functools import cache
 from typing import Any, Sequence, cast
 
 from ._rust_extensions import get_rust_operation
-from .assets import open_text
+from .assets import load_json
 from .core import AttackOrder, AttackWave, Gaggle, Glitchling
 
 # Load Rust-accelerated operation if available
@@ -19,8 +18,7 @@ _apostrofae_rust = get_rust_operation("apostrofae")
 def _load_replacement_pairs() -> dict[str, list[tuple[str, str]]]:
     """Load the curated mapping of straight quotes to fancy pairs."""
 
-    with open_text("apostrofae_pairs.json") as handle:
-        data: dict[str, list[Sequence[str]]] = json.load(handle)
+    data: dict[str, list[Sequence[str]]] = load_json("apostrofae_pairs.json")
 
     parsed: dict[str, list[tuple[str, str]]] = {}
     for straight, replacements in data.items():

--- a/src/glitchlings/zoo/assets/__init__.py
+++ b/src/glitchlings/zoo/assets/__init__.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import json
+from hashlib import blake2b
 from importlib import resources
 from importlib.resources.abc import Traversable
-from typing import BinaryIO, TextIO, cast
+from typing import Any, BinaryIO, TextIO, cast
+
+
+_DEFAULT_DIGEST_SIZE = 32
 
 
 def _asset(name: str) -> Traversable:
@@ -30,4 +35,21 @@ def open_binary(name: str) -> BinaryIO:
     return cast(BinaryIO, _asset(name).open("rb"))
 
 
-__all__ = ["read_text", "open_text", "open_binary"]
+def load_json(name: str, *, encoding: str = "utf-8") -> Any:
+    """Deserialize a JSON asset using the shared loader helpers."""
+
+    with open_text(name, encoding=encoding) as handle:
+        return json.load(handle)
+
+
+def hash_asset(name: str) -> str:
+    """Return a BLAKE2b digest for the bundled asset ``name``."""
+
+    digest = blake2b(digest_size=_DEFAULT_DIGEST_SIZE)
+    with open_binary(name) as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+__all__ = ["read_text", "open_text", "open_binary", "load_json", "hash_asset"]

--- a/tests/util/test_apostrofae_assets.py
+++ b/tests/util/test_apostrofae_assets.py
@@ -1,14 +1,22 @@
 from __future__ import annotations
 
-import json
+import hashlib
 from pathlib import Path
 
+from glitchlings.dev.sync_assets import RUST_VENDORED_ASSETS, sync_assets
 from glitchlings.zoo import assets
 
 
 def _load_apostrofae_pairs() -> dict[str, list[list[str]]]:
-    with assets.open_text("apostrofae_pairs.json") as handle:
-        return json.load(handle)
+    return assets.load_json("apostrofae_pairs.json")
+
+
+def _hash_path(path: Path) -> str:
+    digest = hashlib.blake2b(digest_size=32)
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def test_apostrofae_pairs_asset_structure():
@@ -44,7 +52,8 @@ def test_ocr_confusions_asset_unique_source():
     assert canonical_asset.exists(), "missing OCR confusion table"
     assert not duplicate_asset.exists(), "unexpected duplicate OCR confusion table copy"
     assert rust_packaged_asset.exists(), "missing staged OCR confusion table for Rust"
-    assert canonical_asset.read_text(encoding="utf-8") == rust_packaged_asset.read_text(encoding="utf-8"), (
+    canonical_digest = assets.hash_asset("ocr_confusions.tsv")
+    assert canonical_digest == _hash_path(rust_packaged_asset), (
         "Rust packaged OCR confusion table diverges from canonical asset",
     )
 
@@ -58,6 +67,28 @@ def test_hokey_assets_shared_source():
     assert canonical_asset.exists(), "missing Hokey stretchability asset"
     assert not legacy_asset.exists(), "unexpected legacy Hokey asset location lingering"
     assert rust_packaged_asset.exists(), "missing staged Hokey asset for Rust"
-    assert canonical_asset.read_text(encoding="utf-8") == rust_packaged_asset.read_text(encoding="utf-8"), (
+    canonical_digest = assets.hash_asset("hokey_assets.json")
+    assert canonical_digest == _hash_path(rust_packaged_asset), (
         "Rust packaged Hokey asset diverges from canonical asset",
     )
+
+
+def test_vendored_assets_match_canonical_digests():
+    repo_root = Path(__file__).resolve().parents[2]
+    rust_asset_dir = repo_root / "rust/zoo/assets"
+
+    canonical_digests = {
+        name: assets.hash_asset(name)
+        for name in sorted(RUST_VENDORED_ASSETS)
+    }
+
+    for name, canonical_digest in canonical_digests.items():
+        staged_path = rust_asset_dir / name
+        assert staged_path.exists(), f"missing staged asset {name}"
+        assert canonical_digest == _hash_path(staged_path), (
+            f"vendored asset {name} diverges from canonical digest",
+        )
+
+
+def test_sync_assets_check_passes():
+    assert sync_assets(check=True, quiet=True)


### PR DESCRIPTION
## Summary
- add a `hash_asset` helper for bundled resources so callers can compute canonical digests
- extend the asset integrity tests to compare vendored copies against canonical hashes
- record the checksum coverage in the technical debt journal and outline the next follow-up tasks

## Testing
- pytest tests/util/test_apostrofae_assets.py --override-ini=addopts=


------
https://chatgpt.com/codex/tasks/task_e_68ffc26142fc8332a3f03cb0175771a5