### PR TITLE
Fix lint issues in asset utilities

### DIFF
--- a/src/glitchlings/dev/sync_assets.py
+++ b/src/glitchlings/dev/sync_assets.py
@@ -54,7 +54,11 @@ def sync_assets(
     canonical_dir = _canonical_asset_dir(root)
     rust_dir = _rust_asset_dir(root)
 
-    missing_sources = [name for name in RUST_VENDORED_ASSETS if not (canonical_dir / name).is_file()]
+    missing_sources = [
+        name
+        for name in RUST_VENDORED_ASSETS
+        if not (canonical_dir / name).is_file()
+    ]
     if missing_sources:
         missing_list = ", ".join(sorted(missing_sources))
         raise RuntimeError(f"missing canonical assets: {missing_list}")
@@ -82,7 +86,10 @@ def sync_assets(
                     )
                 for extra in extraneous:
                     print(
-                        f"unexpected vendored asset {extra.relative_to(root)}; run sync_assets to prune it",
+                        (
+                            "unexpected vendored asset "
+                            f"{extra.relative_to(root)}; run sync_assets to prune it"
+                        ),
                         file=sys.stderr,
                     )
             return False

--- a/src/glitchlings/zoo/_rate.py
+++ b/src/glitchlings/zoo/_rate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+
 def resolve_rate(
     *,
     rate: float | None,

--- a/src/glitchlings/zoo/assets/__init__.py
+++ b/src/glitchlings/zoo/assets/__init__.py
@@ -6,7 +6,6 @@ from importlib import resources
 from importlib.resources.abc import Traversable
 from typing import Any, BinaryIO, TextIO, cast
 
-
 _DEFAULT_DIGEST_SIZE = 32
 
 


### PR DESCRIPTION
## Summary
- wrap long diagnostic messages in `sync_assets` to satisfy the line-length check
- let Ruff organize imports in the asset utilities modules

## Testing
- `ruff check src/glitchlings/dev/sync_assets.py src/glitchlings/zoo/_rate.py src/glitchlings/zoo/assets/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_69000cb0d0f48332a7fef1c3881ac767